### PR TITLE
feat: stipple brush for 1-bit shading (BWC-5)

### DIFF
--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -62,10 +62,12 @@ canvas.addEventListener('pointerdown', (e) => {
 canvas.addEventListener('pointermove', (e) => {
   if (!stippleDensity || !stippleActive || !e.isPrimary) return;
   const { offsetX: x, offsetY: y } = e;
-  stippleSegments.push({ point: { x, y }, time: performance.now() });
   const dx = x - stippleLastPoint.x;
   const dy = y - stippleLastPoint.y;
-  stippleDistSinceDot += Math.sqrt(dx * dx + dy * dy);
+  const dist = Math.sqrt(dx * dx + dy * dy);
+  if (dist < 1) return;
+  stippleSegments.push({ point: { x, y }, time: performance.now() });
+  stippleDistSinceDot += dist;
   if (stippleDistSinceDot >= STIPPLE_PRESETS[stippleDensity].spacing) {
     plotDot(x, y);
     stippleDistSinceDot = 0;
@@ -106,6 +108,7 @@ sketchpad.addEventListener('strokerecorded', (obj) => {
 canvas.addEventListener('click', (e) => {
   // Stipple clicks are already handled by pointerdown/pointerup — skip
   if (stippleDensity) return;
+  if (strokes.length === 0) return;
   const bounds = sketchpad.canvas.getBoundingClientRect();
   const clickPoint = { x: e.clientX, y: e.clientY }
   if (strokes[strokes.length - 1].segments.length < 3) {

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -1,5 +1,5 @@
 // HTML Canvas: https://github.com/jakubfiala/atrament
-import Atrament, { MODE_DRAW, MODE_ERASE } from 'atrament';
+import Atrament, { MODE_DRAW, MODE_ERASE, MODE_DISABLED } from 'atrament';
 
 // Re-export mode constants
 export { MODE_DRAW, MODE_ERASE };
@@ -27,15 +27,47 @@ export const strokes = [];
 export const redoStack = [];
 let isUndoRedoInProgress = false;
 
+// Stipple mode — plots dots at varying density to simulate shading within the 1-bit constraint
+const STIPPLE_PRESETS = {
+  light:  { radius: 1,   spacing: 8 },
+  medium: { radius: 1.5, spacing: 4 },
+  dark:   { radius: 2,   spacing: 2 },
+};
+const STIPPLE_DENSITIES = [null, 'light', 'medium', 'dark'];
+let stippleDensity = null;
+let stippleCounter = 0;
+
 sketchpad.recordStrokes = true;
-sketchpad.addEventListener('strokerecorded', (obj) => { 
+
+sketchpad.addEventListener('segmentdrawn', ({ stroke }) => {
+  if (!stippleDensity) return;
+  const lastSegment = stroke.segments[stroke.segments.length - 1];
+  if (!lastSegment || Number.isNaN(lastSegment.time)) return;
+  const { x, y } = lastSegment.point;
+  const { radius, spacing } = STIPPLE_PRESETS[stippleDensity];
+  if (stippleCounter % spacing === 0) {
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = 'black';
+    ctx.beginPath();
+    ctx.arc(x, y, radius, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  stippleCounter++;
+});
+
+sketchpad.addEventListener('strokerecorded', (obj) => {
   if (!sketchpad.recordPaused) {
     obj.stroke.type = "stroke";
     obj.stroke.segments = obj.stroke.segments.filter((segment) => !Number.isNaN(segment?.time))
+    if (stippleDensity) {
+      obj.stroke.isStipple = true;
+      obj.stroke.stippleDensity = stippleDensity;
+    }
     strokes.push(obj.stroke);
     // Clear redo stack when new stroke is added
     redoStack.length = 0;
   }
+  stippleCounter = 0;
 });
 
 // Compensate for Dots
@@ -62,15 +94,34 @@ canvas.addEventListener('click', (e) => {
         time: 2,
       },
     ]
-    sketchpad.draw(strokePoints[0].point.x, strokePoints[0].point.y, strokePoints[1].point.x, strokePoints[1].point.y);
+    // In stipple mode, Atrament is disabled so sketchpad.draw() would be a no-op;
+    // the dot was already rendered by segmentdrawn. Skip to avoid mode confusion.
+    if (!stippleDensity) {
+      sketchpad.draw(strokePoints[0].point.x, strokePoints[0].point.y, strokePoints[1].point.x, strokePoints[1].point.y);
+    }
     strokes[strokes.length - 1].segments = (strokePoints);
   }
 })
 
+function replayStippleStroke(stroke) {
+  const replayCanvas = document.getElementById("sketchpad");
+  const ctx = replayCanvas?.getContext('2d');
+  if (!ctx) return;
+  const { radius, spacing } = STIPPLE_PRESETS[stroke.stippleDensity];
+  stroke.segments.forEach((seg, i) => {
+    if (i % spacing === 0) {
+      ctx.fillStyle = 'black';
+      ctx.beginPath();
+      ctx.arc(seg.point.x, seg.point.y, radius, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  });
+}
+
 export const undo = (baseImage = null) => {
   // Prevent concurrent undo/redo operations
   if (isUndoRedoInProgress) return;
-  
+
   // Don't undo if there are no strokes
   if (strokes.length === 0) return;
 
@@ -94,9 +145,9 @@ export const undo = (baseImage = null) => {
 
   // Draw base image first if provided
   if (baseImage) {
-    const canvas = document.getElementById("sketchpad");
-    const ctx = canvas?.getContext('2d');
-    ctx?.drawImage(baseImage, 0, 0, canvas.width, canvas.height);
+    const replayCanvas = document.getElementById("sketchpad");
+    const ctx = replayCanvas?.getContext('2d');
+    ctx?.drawImage(baseImage, 0, 0, replayCanvas.width, replayCanvas.height);
   }
 
   // Replay all remaining strokes
@@ -106,12 +157,18 @@ export const undo = (baseImage = null) => {
 
     // Handle fill operations
     if (stroke.isFill) {
-      const canvas = document.getElementById("sketchpad");
-      const ctx = canvas?.getContext('2d');
-      if (ctx && canvas) {
+      const replayCanvas = document.getElementById("sketchpad");
+      const ctx = replayCanvas?.getContext('2d');
+      if (ctx && replayCanvas) {
         ctx.fillStyle = stroke.color;
-        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.fillRect(0, 0, replayCanvas.width, replayCanvas.height);
       }
+      continue;
+    }
+
+    // Handle stipple operations
+    if (stroke.isStipple) {
+      replayStippleStroke(stroke);
       continue;
     }
 
@@ -163,7 +220,7 @@ export const undo = (baseImage = null) => {
 export const redo = (baseImage = null) => {
   // Prevent concurrent undo/redo operations
   if (isUndoRedoInProgress) return;
-  
+
   if (redoStack.length === 0) return;
 
   isUndoRedoInProgress = true;
@@ -183,10 +240,10 @@ export const redo = (baseImage = null) => {
 
   // If base image provided, redraw everything
   if (baseImage) {
-    const canvas = document.getElementById("sketchpad");
-    const ctx = canvas?.getContext('2d');
-    ctx?.clearRect(0, 0, canvas.width, canvas.height);
-    ctx?.drawImage(baseImage, 0, 0, canvas.width, canvas.height);
+    const replayCanvas = document.getElementById("sketchpad");
+    const ctx = replayCanvas?.getContext('2d');
+    ctx?.clearRect(0, 0, replayCanvas.width, replayCanvas.height);
+    ctx?.drawImage(baseImage, 0, 0, replayCanvas.width, replayCanvas.height);
 
     // Replay all strokes
     for (let i = 0; i < strokes.length; i++) {
@@ -196,7 +253,13 @@ export const redo = (baseImage = null) => {
       // Handle fill operations
       if (stroke.isFill) {
         ctx.fillStyle = stroke.color;
-        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.fillRect(0, 0, replayCanvas.width, replayCanvas.height);
+        continue;
+      }
+
+      // Handle stipple operations
+      if (stroke.isStipple) {
+        replayStippleStroke(stroke);
         continue;
       }
 
@@ -223,33 +286,44 @@ export const redo = (baseImage = null) => {
     // Just replay the restored stroke
     const stroke = restoredStroke;
     if (stroke?.segments?.length) {
-      sketchpad.mode = stroke.mode;
-      sketchpad.weight = stroke.weight;
-      sketchpad.smoothing = stroke.smoothing;
-      sketchpad.color = stroke.color;
-      sketchpad.adaptiveStroke = stroke.adaptiveStroke;
+      if (stroke.isStipple) {
+        replayStippleStroke(stroke);
+      } else if (stroke.isFill) {
+        const replayCanvas = document.getElementById("sketchpad");
+        const ctx = replayCanvas?.getContext('2d');
+        if (ctx) {
+          ctx.fillStyle = stroke.color;
+          ctx.fillRect(0, 0, replayCanvas.width, replayCanvas.height);
+        }
+      } else {
+        sketchpad.mode = stroke.mode;
+        sketchpad.weight = stroke.weight;
+        sketchpad.smoothing = stroke.smoothing;
+        sketchpad.color = stroke.color;
+        sketchpad.adaptiveStroke = stroke.adaptiveStroke;
 
-      const segments = [...stroke.segments];
-      const firstSegment = segments.shift();
-      const firstPoint = firstSegment.point;
-      sketchpad.beginStroke(firstPoint.x, firstPoint.y);
+        const segments = [...stroke.segments];
+        const firstSegment = segments.shift();
+        const firstPoint = firstSegment.point;
+        sketchpad.beginStroke(firstPoint.x, firstPoint.y);
 
-      let prevPoint = firstPoint;
-      while (segments.length > 0) {
-        const segment = segments.shift();
-        const point = segment.point;
-        const pressure = segment.pressure !== undefined ? segment.pressure : 0.5;
-        const { x, y } = sketchpad.draw(
-          point.x,
-          point.y,
-          prevPoint.x,
-          prevPoint.y,
-          pressure
-        );
-        prevPoint = { x, y };
+        let prevPoint = firstPoint;
+        while (segments.length > 0) {
+          const segment = segments.shift();
+          const point = segment.point;
+          const pressure = segment.pressure !== undefined ? segment.pressure : 0.5;
+          const { x, y } = sketchpad.draw(
+            point.x,
+            point.y,
+            prevPoint.x,
+            prevPoint.y,
+            pressure
+          );
+          prevPoint = { x, y };
+        }
+
+        sketchpad.endStroke(prevPoint.x, prevPoint.y);
       }
-
-      sketchpad.endStroke(prevPoint.x, prevPoint.y);
     }
   }
 
@@ -275,20 +349,20 @@ export const getMode = () => {
 }
 
 export const fillWhite = () => {
-  const canvas = document.getElementById("sketchpad");
-  if (!canvas) return;
-  
-  const ctx = canvas.getContext('2d');
+  const fillCanvas = document.getElementById("sketchpad");
+  if (!fillCanvas) return;
+
+  const ctx = fillCanvas.getContext('2d');
   if (!ctx) return;
-  
+
   // Save current settings
   const originalColor = sketchpad.color;
   const originalWeight = sketchpad.weight;
-  
+
   // Fill canvas with white using native canvas API
   ctx.fillStyle = 'white';
-  ctx.fillRect(0, 0, canvas.width, canvas.height);
-  
+  ctx.fillRect(0, 0, fillCanvas.width, fillCanvas.height);
+
   // Record as a stroke for undo functionality
   strokes.push({
     segments: [{
@@ -297,14 +371,14 @@ export const fillWhite = () => {
       pressure: 1
     }],
     color: 'white',
-    weight: canvas.width,
+    weight: fillCanvas.width,
     smoothing: sketchpad.smoothing,
     adaptiveStroke: false,
     mode: MODE_DRAW,
     isFill: true // Mark as fill operation
   });
   redoStack.length = 0;
-  
+
   // Stay in draw mode
   sketchpad.mode = MODE_DRAW;
   sketchpad.color = originalColor;
@@ -324,3 +398,21 @@ export const cycleBrushSize = () => {
 export const getCurrentBrushSize = () => {
   return brushSizeLabels[currentSizeIndex];
 }
+
+export const cycleStippleDensity = () => {
+  const idx = STIPPLE_DENSITIES.indexOf(stippleDensity);
+  stippleDensity = STIPPLE_DENSITIES[(idx + 1) % STIPPLE_DENSITIES.length];
+  sketchpad.mode = stippleDensity ? MODE_DISABLED : MODE_DRAW;
+  stippleCounter = 0;
+  return stippleDensity;
+};
+
+export const getStippleDensity = () => stippleDensity;
+
+export const resetStipple = () => {
+  if (stippleDensity) {
+    sketchpad.mode = MODE_DRAW;
+  }
+  stippleDensity = null;
+  stippleCounter = 0;
+};

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -31,9 +31,9 @@ let isUndoRedoInProgress = false;
 // NOTE: segmentdrawn only fires inside Atrament's draw(), which is skipped in MODE_DISABLED.
 // We track pointer events directly and use distance-based dot spacing instead.
 const STIPPLE_PRESETS = {
-  light:  { radius: 1,   spacing: 12 },
-  medium: { radius: 1.5, spacing: 7 },
-  dark:   { radius: 2,   spacing: 4 },
+  light:  { spacing: 12 },
+  medium: { spacing: 7 },
+  dark:   { spacing: 4 },
 };
 const STIPPLE_DENSITIES = [null, 'light', 'medium', 'dark'];
 let stippleDensity = null;
@@ -48,7 +48,7 @@ function plotDot(x, y) {
   const ctx = canvas.getContext('2d');
   ctx.fillStyle = 'black';
   ctx.beginPath();
-  ctx.arc(x, y, STIPPLE_PRESETS[stippleDensity].radius, 0, Math.PI * 2);
+  ctx.arc(x, y, sketchpad.weight / 2, 0, Math.PI * 2);
   ctx.fill();
 }
 
@@ -79,7 +79,7 @@ function endStippleStroke() {
   if (!stippleActive) return;
   stippleActive = false;
   if (!sketchpad.recordPaused && stippleSegments.length > 0) {
-    strokes.push({ type: 'stroke', segments: stippleSegments, isStipple: true, stippleDensity });
+    strokes.push({ type: 'stroke', segments: stippleSegments, isStipple: true, stippleDensity, weight: sketchpad.weight });
     redoStack.length = 0;
   }
   stippleSegments = [];
@@ -123,7 +123,8 @@ canvas.addEventListener('click', (e) => {
 function replayStippleStroke(stroke) {
   const ctx = document.getElementById("sketchpad")?.getContext('2d');
   if (!ctx) return;
-  const { radius, spacing } = STIPPLE_PRESETS[stroke.stippleDensity];
+  const radius = (stroke.weight ?? 4) / 2;
+  const { spacing } = STIPPLE_PRESETS[stroke.stippleDensity];
   ctx.fillStyle = 'black';
   let lastPoint = null;
   let distSinceDot = 0;

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -27,94 +27,120 @@ export const strokes = [];
 export const redoStack = [];
 let isUndoRedoInProgress = false;
 
-// Stipple mode — plots dots at varying density to simulate shading within the 1-bit constraint
+// Stipple mode — plots dots at varying density to simulate shading within the 1-bit constraint.
+// NOTE: segmentdrawn only fires inside Atrament's draw(), which is skipped in MODE_DISABLED.
+// We track pointer events directly and use distance-based dot spacing instead.
 const STIPPLE_PRESETS = {
-  light:  { radius: 1,   spacing: 8 },
-  medium: { radius: 1.5, spacing: 4 },
-  dark:   { radius: 2,   spacing: 2 },
+  light:  { radius: 1,   spacing: 12 },
+  medium: { radius: 1.5, spacing: 7 },
+  dark:   { radius: 2,   spacing: 4 },
 };
 const STIPPLE_DENSITIES = [null, 'light', 'medium', 'dark'];
 let stippleDensity = null;
-let stippleCounter = 0;
+
+// Live stipple stroke state
+let stippleActive = false;
+let stippleSegments = [];
+let stippleLastPoint = null;
+let stippleDistSinceDot = 0;
+
+function plotDot(x, y) {
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = 'black';
+  ctx.beginPath();
+  ctx.arc(x, y, STIPPLE_PRESETS[stippleDensity].radius, 0, Math.PI * 2);
+  ctx.fill();
+}
+
+canvas.addEventListener('pointerdown', (e) => {
+  if (!stippleDensity || !e.isPrimary || e.button !== 0) return;
+  stippleActive = true;
+  stippleSegments = [{ point: { x: e.offsetX, y: e.offsetY }, time: performance.now() }];
+  stippleLastPoint = { x: e.offsetX, y: e.offsetY };
+  stippleDistSinceDot = 0;
+  plotDot(e.offsetX, e.offsetY);
+});
+
+canvas.addEventListener('pointermove', (e) => {
+  if (!stippleDensity || !stippleActive || !e.isPrimary) return;
+  const { offsetX: x, offsetY: y } = e;
+  stippleSegments.push({ point: { x, y }, time: performance.now() });
+  const dx = x - stippleLastPoint.x;
+  const dy = y - stippleLastPoint.y;
+  stippleDistSinceDot += Math.sqrt(dx * dx + dy * dy);
+  if (stippleDistSinceDot >= STIPPLE_PRESETS[stippleDensity].spacing) {
+    plotDot(x, y);
+    stippleDistSinceDot = 0;
+  }
+  stippleLastPoint = { x, y };
+});
+
+function endStippleStroke() {
+  if (!stippleActive) return;
+  stippleActive = false;
+  if (!sketchpad.recordPaused && stippleSegments.length > 0) {
+    strokes.push({ type: 'stroke', segments: stippleSegments, isStipple: true, stippleDensity });
+    redoStack.length = 0;
+  }
+  stippleSegments = [];
+  stippleLastPoint = null;
+  stippleDistSinceDot = 0;
+}
+
+canvas.addEventListener('pointerup', (e) => { if (e.isPrimary) endStippleStroke(); });
+canvas.addEventListener('pointercancel', (e) => { if (e.isPrimary) endStippleStroke(); });
 
 sketchpad.recordStrokes = true;
 
-sketchpad.addEventListener('segmentdrawn', ({ stroke }) => {
-  if (!stippleDensity) return;
-  const lastSegment = stroke.segments[stroke.segments.length - 1];
-  if (!lastSegment || Number.isNaN(lastSegment.time)) return;
-  const { x, y } = lastSegment.point;
-  const { radius, spacing } = STIPPLE_PRESETS[stippleDensity];
-  if (stippleCounter % spacing === 0) {
-    const ctx = canvas.getContext('2d');
-    ctx.fillStyle = 'black';
-    ctx.beginPath();
-    ctx.arc(x, y, radius, 0, Math.PI * 2);
-    ctx.fill();
-  }
-  stippleCounter++;
-});
-
 sketchpad.addEventListener('strokerecorded', (obj) => {
   if (!sketchpad.recordPaused) {
+    // Stipple strokes are recorded by our pointerup handler above — skip Atrament's recording
+    if (stippleDensity) return;
     obj.stroke.type = "stroke";
     obj.stroke.segments = obj.stroke.segments.filter((segment) => !Number.isNaN(segment?.time))
-    if (stippleDensity) {
-      obj.stroke.isStipple = true;
-      obj.stroke.stippleDensity = stippleDensity;
-    }
     strokes.push(obj.stroke);
     // Clear redo stack when new stroke is added
     redoStack.length = 0;
   }
-  stippleCounter = 0;
 });
 
 // Compensate for Dots
 canvas.addEventListener('click', (e) => {
+  // Stipple clicks are already handled by pointerdown/pointerup — skip
+  if (stippleDensity) return;
   const bounds = sketchpad.canvas.getBoundingClientRect();
-  const clickPoint = {
-    x: e.clientX,
-    y: e.clientY,
-  }
+  const clickPoint = { x: e.clientX, y: e.clientY }
   if (strokes[strokes.length - 1].segments.length < 3) {
     const strokePoints = [
-      {
-        point: {
-          x: Math.floor(clickPoint.x - bounds.x),
-          y: Math.floor(clickPoint.y - bounds.y),
-        },
-        time: 1,
-      },
-      {
-        point: {
-          x: Math.floor(clickPoint.x - bounds.x),
-          y: Math.floor(clickPoint.y - bounds.y + 1),
-        },
-        time: 2,
-      },
+      { point: { x: Math.floor(clickPoint.x - bounds.x), y: Math.floor(clickPoint.y - bounds.y) }, time: 1 },
+      { point: { x: Math.floor(clickPoint.x - bounds.x), y: Math.floor(clickPoint.y - bounds.y + 1) }, time: 2 },
     ]
-    // In stipple mode, Atrament is disabled so sketchpad.draw() would be a no-op;
-    // the dot was already rendered by segmentdrawn. Skip to avoid mode confusion.
-    if (!stippleDensity) {
-      sketchpad.draw(strokePoints[0].point.x, strokePoints[0].point.y, strokePoints[1].point.x, strokePoints[1].point.y);
-    }
-    strokes[strokes.length - 1].segments = (strokePoints);
+    sketchpad.draw(strokePoints[0].point.x, strokePoints[0].point.y, strokePoints[1].point.x, strokePoints[1].point.y);
+    strokes[strokes.length - 1].segments = strokePoints;
   }
 })
 
 function replayStippleStroke(stroke) {
-  const replayCanvas = document.getElementById("sketchpad");
-  const ctx = replayCanvas?.getContext('2d');
+  const ctx = document.getElementById("sketchpad")?.getContext('2d');
   if (!ctx) return;
   const { radius, spacing } = STIPPLE_PRESETS[stroke.stippleDensity];
+  ctx.fillStyle = 'black';
+  let lastPoint = null;
+  let distSinceDot = 0;
   stroke.segments.forEach((seg, i) => {
-    if (i % spacing === 0) {
-      ctx.fillStyle = 'black';
-      ctx.beginPath();
-      ctx.arc(seg.point.x, seg.point.y, radius, 0, Math.PI * 2);
-      ctx.fill();
+    const { x, y } = seg.point;
+    if (i === 0) {
+      ctx.beginPath(); ctx.arc(x, y, radius, 0, Math.PI * 2); ctx.fill();
+      lastPoint = { x, y };
+      return;
     }
+    const dx = x - lastPoint.x, dy = y - lastPoint.y;
+    distSinceDot += Math.sqrt(dx * dx + dy * dy);
+    if (distSinceDot >= spacing) {
+      ctx.beginPath(); ctx.arc(x, y, radius, 0, Math.PI * 2); ctx.fill();
+      distSinceDot = 0;
+    }
+    lastPoint = { x, y };
   });
 }
 
@@ -403,16 +429,16 @@ export const cycleStippleDensity = () => {
   const idx = STIPPLE_DENSITIES.indexOf(stippleDensity);
   stippleDensity = STIPPLE_DENSITIES[(idx + 1) % STIPPLE_DENSITIES.length];
   sketchpad.mode = stippleDensity ? MODE_DISABLED : MODE_DRAW;
-  stippleCounter = 0;
   return stippleDensity;
 };
 
 export const getStippleDensity = () => stippleDensity;
 
 export const resetStipple = () => {
-  if (stippleDensity) {
-    sketchpad.mode = MODE_DRAW;
-  }
+  if (stippleDensity) sketchpad.mode = MODE_DRAW;
   stippleDensity = null;
-  stippleCounter = 0;
+  stippleActive = false;
+  stippleSegments = [];
+  stippleLastPoint = null;
+  stippleDistSinceDot = 0;
 };

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -31,11 +31,9 @@ let isUndoRedoInProgress = false;
 // NOTE: segmentdrawn only fires inside Atrament's draw(), which is skipped in MODE_DISABLED.
 // We track pointer events directly and use distance-based dot spacing instead.
 const STIPPLE_PRESETS = {
-  light:  { spacing: 12 },
-  medium: { spacing: 7 },
-  dark:   { spacing: 4 },
+  light: { spacing: 12 },
 };
-const STIPPLE_DENSITIES = [null, 'light', 'medium', 'dark'];
+const STIPPLE_DENSITIES = [null, 'light'];
 let stippleDensity = null;
 
 // Live stipple stroke state

--- a/src/Components/ActionSpace.tsx
+++ b/src/Components/ActionSpace.tsx
@@ -7,7 +7,7 @@ import { Card, getCardsByLocation, getCardsByOwner } from '../Cards';
 import { Icon } from './Icons';
 import { useState, useEffect, useContext, useRef, useCallback } from 'react';
 //@ts-expect-error: JS Module
-import { undo, redo, strokes, sketchpad, cycleStippleDensity, resetStipple } from '../Canvas.js';
+import { undo, redo, strokes, sketchpad, cycleStippleDensity, resetStipple, fillWhite, cycleBrushSize, getCurrentBrushSize, getMode, setMode as setCanvasMode, MODE_DRAW, MODE_ERASE } from '../Canvas.js';
 import { Link, useNavigate } from 'react-router';
 import { AuthContext, FocusContext, LoadingContext } from '../lib/contexts.ts';
 import { openDeckEditor } from '../lib/data.ts';
@@ -28,6 +28,8 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
   const { loading, setLoading } = useContext(LoadingContext);
   const [submitStatus, setSubmitStatus] = useState('Submit');
   const [stippleDensity, setStippleDensity] = useState<string | null>(null);
+  const [eraserActive, setEraserActive] = useState(false);
+  const [brushSize, setBrushSize] = useState('Medium');
   const { focus, setFocus } = useContext(FocusContext);
   const focusCard = useCallback(((id: number, focusState: boolean) => {
     if (focus?.id != id && focusState == true) {
@@ -157,9 +159,14 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
   }, [setAuth, navigate])
 
   useEffect(() => {
-    if (mode !== 'create-sketch') {
+    if (mode === 'create-sketch') {
+      setCanvasMode(MODE_DRAW);
+      setEraserActive(false);
+      setBrushSize(getCurrentBrushSize());
+    } else {
       resetStipple();
       setStippleDensity(null);
+      setEraserActive(false);
     }
   }, [mode]);
 
@@ -337,17 +344,28 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
       <wired-card style={styles.button} onClick={() => { setMode('create-sketch') }} elevation={2}><Icon name='create' />Create</wired-card>
     </>
   } else if (mode === 'create-sketch') {
+    const sketchTopRow = (
+      <div style={{ position: 'fixed', top: '20px', left: '50%', transform: 'translateX(-50%)', zIndex: 10, display: 'flex', gap: '1em' }}>
+        <wired-card style={{ ...styles.button, color: 'red' }} onClick={() => { fillWhite(); setEraserActive(false); }} elevation={2}><Icon name='discard' />Clear</wired-card>
+        <wired-card style={{ ...styles.button }} onClick={() => { setBrushSize(cycleBrushSize()); }} elevation={2}><Icon name='weight' />{brushSize}</wired-card>
+        <wired-card style={{ ...styles.button, color: eraserActive ? 'red' : undefined }} onClick={() => {
+          const newMode = getMode() === MODE_ERASE ? MODE_DRAW : MODE_ERASE;
+          setCanvasMode(newMode);
+          setEraserActive(newMode === MODE_ERASE);
+          if (newMode === MODE_ERASE) { resetStipple(); setStippleDensity(null); }
+        }} elevation={2}><Icon name='wand' />Erase</wired-card>
+        <wired-card style={{ ...styles.button, backgroundColor: stippleDensity ? '#ddd' : '#eee' }} onClick={() => {
+          const next = cycleStippleDensity();
+          setStippleDensity(next);
+          if (next) setEraserActive(false);
+        }} elevation={2}><Icon name='stipple' />{stippleDensity ? stippleDensity.charAt(0).toUpperCase() + stippleDensity.slice(1) : 'Stipple'}</wired-card>
+      </div>
+    );
     toolset = <>
+      {sketchTopRow}
       <wired-card style={{ ...styles.button }} onClick={() => { setMode('play') }} elevation={2}><Icon name='exit' />Close</wired-card>
       <wired-card style={{ ...styles.button }} onClick={() => { undo() }} elevation={2}><Icon name='undo' />Undo</wired-card>
       <wired-card style={{ ...styles.button }} onClick={() => { redo() }} elevation={2}><Icon name='redo' />Redo</wired-card>
-      <wired-card
-        style={{ ...styles.button, backgroundColor: stippleDensity ? '#ccc' : '#eee' }}
-        onClick={() => { const next = cycleStippleDensity(); setStippleDensity(next); }}
-        elevation={2}
-      >
-        <Icon name='wand' />{stippleDensity ? stippleDensity.charAt(0).toUpperCase() + stippleDensity.slice(1) : 'Stipple'}
-      </wired-card>
       <wired-card style={{ ...styles.button }} onClick={() => { setMode('create-finalise') }} elevation={2}><Icon name='send' />Next</wired-card>
     </>
   } else if (mode === 'create-finalise') {

--- a/src/Components/ActionSpace.tsx
+++ b/src/Components/ActionSpace.tsx
@@ -359,7 +359,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
           const next = cycleStippleDensity();
           setStippleDensity(next);
           if (next) setEraserActive(false);
-        }} elevation={2}><Icon name='stipple' />Stipple</wired-card>
+        }} elevation={2}><Icon name='stipple' />Shade</wired-card>
       </div>
     );
     toolset = <>

--- a/src/Components/ActionSpace.tsx
+++ b/src/Components/ActionSpace.tsx
@@ -348,13 +348,13 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
     topRow = (
       <div style={{ position: 'fixed', top: 'calc(2em + 12px)', left: '50%', transform: 'translateX(-50%)', zIndex: 10, display: 'flex', gap: '1em' }}>
         <wired-card style={{ ...styles.button, color: 'red' }} onClick={() => { fillWhite(); setEraserActive(false); }} elevation={2}><Icon name='discard' />Clear</wired-card>
-        <wired-card style={{ ...styles.button }} onClick={() => { setBrushSize(cycleBrushSize()); }} elevation={2}><Icon name='weight' />{brushSize}</wired-card>
         <wired-card style={{ ...styles.button, color: eraserActive ? 'red' : undefined }} onClick={() => {
           const newMode = getMode() === MODE_ERASE ? MODE_DRAW : MODE_ERASE;
           setCanvasMode(newMode);
           setEraserActive(newMode === MODE_ERASE);
           if (newMode === MODE_ERASE) { resetStipple(); setStippleDensity(null); }
         }} elevation={2}><Icon name='wand' />Erase</wired-card>
+        <wired-card style={{ ...styles.button }} onClick={() => { setBrushSize(cycleBrushSize()); }} elevation={2}><Icon name='weight' />{brushSize}</wired-card>
         <wired-card style={{ ...styles.button, backgroundColor: stippleDensity ? '#ddd' : '#eee' }} onClick={() => {
           const next = cycleStippleDensity();
           setStippleDensity(next);

--- a/src/Components/ActionSpace.tsx
+++ b/src/Components/ActionSpace.tsx
@@ -354,7 +354,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
           setEraserActive(newMode === MODE_ERASE);
           if (newMode === MODE_ERASE) { resetStipple(); setStippleDensity(null); }
         }} elevation={2}><Icon name='wand' />Erase</wired-card>
-        <wired-card style={{ ...styles.button }} onClick={() => { setBrushSize(cycleBrushSize()); }} elevation={2}><Icon name='weight' />{brushSize}</wired-card>
+        <wired-card style={{ ...styles.button }} onClick={() => { setBrushSize(cycleBrushSize()); }} elevation={2}><Icon name={brushSize === 'Small' ? 'size_sm' : brushSize === 'Large' ? 'size_lg' : 'size_md'} />{brushSize}</wired-card>
         <wired-card style={{ ...styles.button }} onClick={() => {
           const next = cycleStippleDensity();
           setStippleDensity(next);

--- a/src/Components/ActionSpace.tsx
+++ b/src/Components/ActionSpace.tsx
@@ -346,7 +346,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
     </>
   } else if (mode === 'create-sketch') {
     topRow = (
-      <div style={{ position: 'fixed', top: '20px', left: '50%', transform: 'translateX(-50%)', zIndex: 10, display: 'flex', gap: '1em' }}>
+      <div style={{ position: 'fixed', top: 'calc(2em + 12px)', left: '50%', transform: 'translateX(-50%)', zIndex: 10, display: 'flex', gap: '1em' }}>
         <wired-card style={{ ...styles.button, color: 'red' }} onClick={() => { fillWhite(); setEraserActive(false); }} elevation={2}><Icon name='discard' />Clear</wired-card>
         <wired-card style={{ ...styles.button }} onClick={() => { setBrushSize(cycleBrushSize()); }} elevation={2}><Icon name='weight' />{brushSize}</wired-card>
         <wired-card style={{ ...styles.button, color: eraserActive ? 'red' : undefined }} onClick={() => {

--- a/src/Components/ActionSpace.tsx
+++ b/src/Components/ActionSpace.tsx
@@ -7,7 +7,7 @@ import { Card, getCardsByLocation, getCardsByOwner } from '../Cards';
 import { Icon } from './Icons';
 import { useState, useEffect, useContext, useRef, useCallback } from 'react';
 //@ts-expect-error: JS Module
-import { undo, redo, strokes, sketchpad } from '../Canvas.js';
+import { undo, redo, strokes, sketchpad, cycleStippleDensity, resetStipple } from '../Canvas.js';
 import { Link, useNavigate } from 'react-router';
 import { AuthContext, FocusContext, LoadingContext } from '../lib/contexts.ts';
 import { openDeckEditor } from '../lib/data.ts';
@@ -27,6 +27,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
   const { setAuth } = useContext(AuthContext);
   const { loading, setLoading } = useContext(LoadingContext);
   const [submitStatus, setSubmitStatus] = useState('Submit');
+  const [stippleDensity, setStippleDensity] = useState<string | null>(null);
   const { focus, setFocus } = useContext(FocusContext);
   const focusCard = useCallback(((id: number, focusState: boolean) => {
     if (focus?.id != id && focusState == true) {
@@ -154,6 +155,13 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
     setAuth({});
     navigate('/');
   }, [setAuth, navigate])
+
+  useEffect(() => {
+    if (mode !== 'create-sketch') {
+      resetStipple();
+      setStippleDensity(null);
+    }
+  }, [mode]);
 
   // Track number of moves made by the player to debounce button
   const moveTracker = useRef({ numMoves: 0, timestamp: (new Date()).getTime() });
@@ -333,6 +341,13 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
       <wired-card style={{ ...styles.button }} onClick={() => { setMode('play') }} elevation={2}><Icon name='exit' />Close</wired-card>
       <wired-card style={{ ...styles.button }} onClick={() => { undo() }} elevation={2}><Icon name='undo' />Undo</wired-card>
       <wired-card style={{ ...styles.button }} onClick={() => { redo() }} elevation={2}><Icon name='redo' />Redo</wired-card>
+      <wired-card
+        style={{ ...styles.button, backgroundColor: stippleDensity ? '#ccc' : '#eee' }}
+        onClick={() => { const next = cycleStippleDensity(); setStippleDensity(next); }}
+        elevation={2}
+      >
+        <Icon name='wand' />{stippleDensity ? stippleDensity.charAt(0).toUpperCase() + stippleDensity.slice(1) : 'Stipple'}
+      </wired-card>
       <wired-card style={{ ...styles.button }} onClick={() => { setMode('create-finalise') }} elevation={2}><Icon name='send' />Next</wired-card>
     </>
   } else if (mode === 'create-finalise') {

--- a/src/Components/ActionSpace.tsx
+++ b/src/Components/ActionSpace.tsx
@@ -359,7 +359,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
           const next = cycleStippleDensity();
           setStippleDensity(next);
           if (next) setEraserActive(false);
-        }} elevation={2}><Icon name={stippleDensity ? 'stipple' : 'solid'} />{stippleDensity ? 'Dotted' : 'Solid'}</wired-card>
+        }} elevation={2}><Icon name={stippleDensity ? 'stipple' : 'solid'} />{stippleDensity ? 'Dots' : 'Solid'}</wired-card>
       </div>
     );
     toolset = <>

--- a/src/Components/ActionSpace.tsx
+++ b/src/Components/ActionSpace.tsx
@@ -359,7 +359,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
           const next = cycleStippleDensity();
           setStippleDensity(next);
           if (next) setEraserActive(false);
-        }} elevation={2}><Icon name='stipple' />Shade</wired-card>
+        }} elevation={2}><Icon name='stipple' />{stippleDensity ? 'Shade' : 'Solid'}</wired-card>
       </div>
     );
     toolset = <>

--- a/src/Components/ActionSpace.tsx
+++ b/src/Components/ActionSpace.tsx
@@ -359,7 +359,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
           const next = cycleStippleDensity();
           setStippleDensity(next);
           if (next) setEraserActive(false);
-        }} elevation={2}><Icon name={stippleDensity ? 'stipple' : 'solid'} />{stippleDensity ? 'Shade' : 'Solid'}</wired-card>
+        }} elevation={2}><Icon name={stippleDensity ? 'stipple' : 'solid'} />{stippleDensity ? 'Dotted' : 'Solid'}</wired-card>
       </div>
     );
     toolset = <>

--- a/src/Components/ActionSpace.tsx
+++ b/src/Components/ActionSpace.tsx
@@ -265,6 +265,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
   };
 
   // Initialise Buttons
+  let topRow = null;
   let toolset;
   if (mode === 'play') {
     let mainButtonContent;
@@ -344,7 +345,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
       <wired-card style={styles.button} onClick={() => { setMode('create-sketch') }} elevation={2}><Icon name='create' />Create</wired-card>
     </>
   } else if (mode === 'create-sketch') {
-    const sketchTopRow = (
+    topRow = (
       <div style={{ position: 'fixed', top: '20px', left: '50%', transform: 'translateX(-50%)', zIndex: 10, display: 'flex', gap: '1em' }}>
         <wired-card style={{ ...styles.button, color: 'red' }} onClick={() => { fillWhite(); setEraserActive(false); }} elevation={2}><Icon name='discard' />Clear</wired-card>
         <wired-card style={{ ...styles.button }} onClick={() => { setBrushSize(cycleBrushSize()); }} elevation={2}><Icon name='weight' />{brushSize}</wired-card>
@@ -362,7 +363,6 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
       </div>
     );
     toolset = <>
-      {sketchTopRow}
       <wired-card style={{ ...styles.button }} onClick={() => { setMode('play') }} elevation={2}><Icon name='exit' />Close</wired-card>
       <wired-card style={{ ...styles.button }} onClick={() => { undo() }} elevation={2}><Icon name='undo' />Undo</wired-card>
       <wired-card style={{ ...styles.button }} onClick={() => { redo() }} elevation={2}><Icon name='redo' />Redo</wired-card>
@@ -444,9 +444,12 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
   }
 
   return (
-    <div style={styles.toolbar} >
-      {toolset}
-    </div>
+    <>
+      {topRow}
+      <div style={styles.toolbar} >
+        {toolset}
+      </div>
+    </>
   );
 }
 

--- a/src/Components/ActionSpace.tsx
+++ b/src/Components/ActionSpace.tsx
@@ -346,7 +346,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
     </>
   } else if (mode === 'create-sketch') {
     topRow = (
-      <div style={{ position: 'fixed', top: 'calc(2em + 12px)', left: '50%', transform: 'translateX(-50%)', zIndex: 10, display: 'flex', gap: '1em' }}>
+      <div style={{ position: 'fixed', top: 'calc(2em + 12px)', left: '50%', transform: 'translateX(-50%)', zIndex: 10, display: 'flex', justifyContent: 'space-around', width: '100%', maxWidth: '40em' }}>
         <wired-card style={{ ...styles.button, color: 'red' }} onClick={() => { fillWhite(); setEraserActive(false); }} elevation={2}><Icon name='discard' />Clear</wired-card>
         <wired-card style={{ ...styles.button, color: eraserActive ? 'red' : undefined }} onClick={() => {
           const newMode = getMode() === MODE_ERASE ? MODE_DRAW : MODE_ERASE;

--- a/src/Components/ActionSpace.tsx
+++ b/src/Components/ActionSpace.tsx
@@ -354,7 +354,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
           setEraserActive(newMode === MODE_ERASE);
           if (newMode === MODE_ERASE) { resetStipple(); setStippleDensity(null); }
         }} elevation={2}><Icon name='wand' />Erase</wired-card>
-        <wired-card style={{ ...styles.button }} onClick={() => { setBrushSize(cycleBrushSize()); }} elevation={2}><Icon name={brushSize === 'Small' ? 'size_sm' : brushSize === 'Large' ? 'size_lg' : 'size_md'} />{brushSize}</wired-card>
+        <wired-card style={{ ...styles.button }} onClick={() => { setBrushSize(cycleBrushSize()); }} elevation={2}><Icon name='weight' />{brushSize}</wired-card>
         <wired-card style={{ ...styles.button }} onClick={() => {
           const next = cycleStippleDensity();
           setStippleDensity(next);

--- a/src/Components/ActionSpace.tsx
+++ b/src/Components/ActionSpace.tsx
@@ -359,7 +359,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
           const next = cycleStippleDensity();
           setStippleDensity(next);
           if (next) setEraserActive(false);
-        }} elevation={2}><Icon name='stipple' />{stippleDensity ? stippleDensity.charAt(0).toUpperCase() + stippleDensity.slice(1) : 'Stipple'}</wired-card>
+        }} elevation={2}><Icon name='stipple' />Stipple</wired-card>
       </div>
     );
     toolset = <>

--- a/src/Components/ActionSpace.tsx
+++ b/src/Components/ActionSpace.tsx
@@ -359,7 +359,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
           const next = cycleStippleDensity();
           setStippleDensity(next);
           if (next) setEraserActive(false);
-        }} elevation={2}><Icon name='stipple' />{stippleDensity ? 'Shade' : 'Solid'}</wired-card>
+        }} elevation={2}><Icon name={stippleDensity ? 'stipple' : 'solid'} />{stippleDensity ? 'Shade' : 'Solid'}</wired-card>
       </div>
     );
     toolset = <>

--- a/src/Components/ActionSpace.tsx
+++ b/src/Components/ActionSpace.tsx
@@ -355,7 +355,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
           if (newMode === MODE_ERASE) { resetStipple(); setStippleDensity(null); }
         }} elevation={2}><Icon name='wand' />Erase</wired-card>
         <wired-card style={{ ...styles.button }} onClick={() => { setBrushSize(cycleBrushSize()); }} elevation={2}><Icon name='weight' />{brushSize}</wired-card>
-        <wired-card style={{ ...styles.button, backgroundColor: stippleDensity ? '#ddd' : '#eee' }} onClick={() => {
+        <wired-card style={{ ...styles.button }} onClick={() => {
           const next = cycleStippleDensity();
           setStippleDensity(next);
           if (next) setEraserActive(false);

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -968,7 +968,7 @@ export function DeckEditor() {
                 </>
               ) : (
                 <>
-                  <h3 style={styles.modalTitle}>Deck Editor</h3>
+                  <h3 style={styles.modalTitle}>{deck.cards.length === 0 ? 'Welcome to the Deck Editor' : 'Deck Editor'}</h3>
                   <div style={styles.fileModalButtons}>
                     {deck.cards.length === 0 ? (
                       <div style={styles.fileModalRow}>

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -138,7 +138,7 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
           style={styles.button}
           onClick={handleStippleToggle}
         >
-          <Icon name="stipple" />
+          <Icon name={stippleDensity ? 'stipple' : 'solid'} />
           {stippleDensity ? 'Shade' : 'Solid'}
         </wired-card>
       </div>

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -135,10 +135,7 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
         </wired-card>
         <wired-card
           elevation={2}
-          style={{
-            ...styles.button,
-            backgroundColor: stippleDensity ? '#ddd' : 'white'
-          }}
+          style={styles.button}
           onClick={handleStippleToggle}
         >
           <Icon name="stipple" />

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -883,15 +883,15 @@ export function DeckEditor() {
                 <>
                   <h3 style={styles.modalTitle}>Restart</h3>
                   <p>Are you sure you want to restart? This will clear all cards from the editor and cannot be undone.</p>
-                  <div style={styles.fileModalButtons}>
-                    <wired-card 
-                      style={styles.saveButton} 
-                      onClick={() => setModalState('closed')} 
+                  <div style={styles.fileModalRow}>
+                    <wired-card
+                      style={styles.saveButton}
+                      onClick={() => setModalState('closed')}
                       elevation={2}
                     >
                       <Icon name="exit" /> Cancel
                     </wired-card>
-                    <wired-card 
+                    <wired-card
                       style={{
                         ...styles.saveButton,
                         color: '#f44336'

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -969,6 +969,7 @@ export function DeckEditor() {
               ) : (
                 <>
                   <h3 style={styles.modalTitle}>{deck.cards.length === 0 ? 'Welcome to the Deck Editor' : 'Deck Editor'}</h3>
+                  {deck.cards.length === 0 && <p>Load decks from your saved files, edit cards, and Save a new deck</p>}
                   <div style={styles.fileModalButtons}>
                     {deck.cards.length === 0 ? (
                       <div style={styles.fileModalRow}>

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -130,7 +130,7 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
           Erase
         </wired-card>
         <wired-card elevation={2} style={styles.button} onClick={handleBrushSizeToggle}>
-          <Icon name={brushSize === 'Small' ? 'size_sm' : brushSize === 'Large' ? 'size_lg' : 'size_md'} />
+          <Icon name="weight" />
           {brushSize}
         </wired-card>
         <wired-card

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -142,7 +142,7 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
           onClick={handleStippleToggle}
         >
           <Icon name="stipple" />
-          {stippleDensity ? stippleDensity.charAt(0).toUpperCase() + stippleDensity.slice(1) : 'Stipple'}
+          Stipple
         </wired-card>
       </div>
       <div style={styles.bottomRow}>

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -142,7 +142,7 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
           onClick={handleStippleToggle}
         >
           <Icon name="stipple" />
-          Shade
+          {stippleDensity ? 'Shade' : 'Solid'}
         </wired-card>
       </div>
       <div style={styles.bottomRow}>

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -885,13 +885,6 @@ export function DeckEditor() {
                   <p>Are you sure you want to restart? This will clear all cards from the editor and cannot be undone.</p>
                   <div style={styles.fileModalRow}>
                     <wired-card
-                      style={styles.saveButton}
-                      onClick={() => setModalState('closed')}
-                      elevation={2}
-                    >
-                      <Icon name="exit" /> Cancel
-                    </wired-card>
-                    <wired-card
                       style={{
                         ...styles.saveButton,
                         color: '#f44336'
@@ -902,6 +895,13 @@ export function DeckEditor() {
                       elevation={2}
                     >
                       <Icon name="shuffle" /> Restart
+                    </wired-card>
+                    <wired-card
+                      style={styles.saveButton}
+                      onClick={() => setModalState('closed')}
+                      elevation={2}
+                    >
+                      <Icon name="exit" /> Cancel
                     </wired-card>
                   </div>
                 </>

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -124,23 +124,23 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
           elevation={2}
           style={{
             ...styles.button,
-            backgroundColor: stippleDensity ? '#ddd' : 'white'
-          }}
-          onClick={handleStippleToggle}
-        >
-          <Icon name="wand" />
-          {stippleDensity ? stippleDensity.charAt(0).toUpperCase() + stippleDensity.slice(1) : 'Stipple'}
-        </wired-card>
-        <wired-card
-          elevation={2}
-          style={{
-            ...styles.button,
             color: eraserActive ? 'red' : undefined
           }}
           onClick={handleEraserToggle}
         >
           <Icon name="wand" />
           Erase
+        </wired-card>
+        <wired-card
+          elevation={2}
+          style={{
+            ...styles.button,
+            backgroundColor: stippleDensity ? '#ddd' : 'white'
+          }}
+          onClick={handleStippleToggle}
+        >
+          <Icon name="stipple" />
+          {stippleDensity ? stippleDensity.charAt(0).toUpperCase() + stippleDensity.slice(1) : 'Stipple'}
         </wired-card>
       </div>
       <div style={styles.bottomRow}>

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -116,10 +116,6 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
           <Icon name="discard" />
           Clear
         </wired-card>
-        <wired-card elevation={2} style={styles.button} onClick={handleBrushSizeToggle}>
-          <Icon name="weight" />
-          {brushSize}
-        </wired-card>
         <wired-card
           elevation={2}
           style={{
@@ -130,6 +126,10 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
         >
           <Icon name="wand" />
           Erase
+        </wired-card>
+        <wired-card elevation={2} style={styles.button} onClick={handleBrushSizeToggle}>
+          <Icon name="weight" />
+          {brushSize}
         </wired-card>
         <wired-card
           elevation={2}

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -6,7 +6,7 @@ import { CardEditor } from './CardEditor';
 import { FullCardView, CompactCardView, ImageOnlyCardView } from './CardViews';
 import { ViewModeToggle } from './EditorControls';
 //@ts-expect-error: JS Module
-import { fillWhite, cycleBrushSize, getCurrentBrushSize, getMode, setMode, MODE_DRAW, MODE_ERASE } from '../../Canvas.js';
+import { fillWhite, cycleBrushSize, getCurrentBrushSize, getMode, setMode, MODE_DRAW, MODE_ERASE, cycleStippleDensity, getStippleDensity, resetStipple } from '../../Canvas.js';
 
 function DrawingControls({ onBack, onUndo, onRedo, onCancel }: { 
   onBack: () => void,
@@ -16,12 +16,15 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
 }) {
   const [eraserActive, setEraserActive] = useState(false);
   const [brushSize, setBrushSize] = useState('Medium');
+  const [stippleDensity, setStippleDensity] = useState<string | null>(null);
   const [handlersReady, setHandlersReady] = useState(false);
 
   // Reset to draw mode when component mounts
   useEffect(() => {
     setMode(MODE_DRAW);
     setEraserActive(false);
+    resetStipple();
+    setStippleDensity(null);
     setBrushSize(getCurrentBrushSize());
   }, []);
 
@@ -34,6 +37,20 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
     const newMode = getMode() === MODE_ERASE ? MODE_DRAW : MODE_ERASE;
     setMode(newMode);
     setEraserActive(newMode === MODE_ERASE);
+    // Deactivate stipple when switching to eraser
+    if (newMode === MODE_ERASE) {
+      resetStipple();
+      setStippleDensity(null);
+    }
+  };
+
+  const handleStippleToggle = () => {
+    const next = cycleStippleDensity();
+    setStippleDensity(next);
+    // Deactivate eraser when stipple is turned on
+    if (next) {
+      setEraserActive(false);
+    }
   };
 
   const handleUndo = () => {
@@ -103,12 +120,23 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
           <Icon name="weight" />
           {brushSize}
         </wired-card>
-        <wired-card 
-          elevation={2} 
+        <wired-card
+          elevation={2}
+          style={{
+            ...styles.button,
+            backgroundColor: stippleDensity ? '#ddd' : 'white'
+          }}
+          onClick={handleStippleToggle}
+        >
+          <Icon name="wand" />
+          {stippleDensity ? stippleDensity.charAt(0).toUpperCase() + stippleDensity.slice(1) : 'Stipple'}
+        </wired-card>
+        <wired-card
+          elevation={2}
           style={{
             ...styles.button,
             color: eraserActive ? 'red' : undefined
-          }} 
+          }}
           onClick={handleEraserToggle}
         >
           <Icon name="wand" />

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -969,7 +969,7 @@ export function DeckEditor() {
               ) : (
                 <>
                   <h3 style={styles.modalTitle}>{deck.cards.length === 0 ? 'Welcome to the Deck Editor' : 'Deck Editor'}</h3>
-                  {deck.cards.length === 0 && <p>Load decks from your saved files, edit cards, and Save a new deck</p>}
+                  <p>Load decks from your saved files, edit cards, and Save a new deck</p>
                   <div style={styles.fileModalButtons}>
                     {deck.cards.length === 0 ? (
                       <div style={styles.fileModalRow}>

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -107,7 +107,7 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
       justifyContent: 'center',
       flexDirection: 'column' as const,
       backgroundColor: 'white',
-      borderRadius: '8px'
+      borderRadius: '1em'
     }
   };
 

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -1017,10 +1017,7 @@ export function DeckEditor() {
                             <Icon name="take" /> Save
                           </wired-card>
                         </div>
-                        <wired-card style={{ ...styles.saveButton, width: '100%' }} onClick={() => setModalState('closed')} elevation={2}>
-                          <Icon name="exit" /> Close
-                        </wired-card>
-                      </>
+</>
                     )}
                     <input
                       ref={fileInputRef}

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -142,7 +142,7 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
           onClick={handleStippleToggle}
         >
           <Icon name="stipple" />
-          Stipple
+          Shade
         </wired-card>
       </div>
       <div style={styles.bottomRow}>

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -130,7 +130,7 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
           Erase
         </wired-card>
         <wired-card elevation={2} style={styles.button} onClick={handleBrushSizeToggle}>
-          <Icon name="weight" />
+          <Icon name={brushSize === 'Small' ? 'size_sm' : brushSize === 'Large' ? 'size_lg' : 'size_md'} />
           {brushSize}
         </wired-card>
         <wired-card

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -139,7 +139,7 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
           onClick={handleStippleToggle}
         >
           <Icon name={stippleDensity ? 'stipple' : 'solid'} />
-          {stippleDensity ? 'Dotted' : 'Solid'}
+          {stippleDensity ? 'Dots' : 'Solid'}
         </wired-card>
       </div>
       <div style={styles.bottomRow}>

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -139,7 +139,7 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
           onClick={handleStippleToggle}
         >
           <Icon name={stippleDensity ? 'stipple' : 'solid'} />
-          {stippleDensity ? 'Shade' : 'Solid'}
+          {stippleDensity ? 'Dotted' : 'Solid'}
         </wired-card>
       </div>
       <div style={styles.bottomRow}>

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -968,64 +968,66 @@ export function DeckEditor() {
                 </>
               ) : (
                 <>
-                  <h3 style={styles.modalTitle}>Welcome to the Deck Editor</h3>
-                  <p>Load decks from your saved files, edit cards, and Save a new deck</p>
+                  <h3 style={styles.modalTitle}>Deck Editor</h3>
                   <div style={styles.fileModalButtons}>
-                    <div style={styles.fileModalRow}>
-                      <wired-card 
-                        style={styles.saveButton}
-                        onClick={() => {
-                          if (confirm('Any unsaved changes will be lost. Are you sure you want to leave?')) {
-                            navigate('/');
-                          }
-                        }}
-                        elevation={2}
-                      >
-                        <Icon name="copy" /> Home
-                      </wired-card>
-
-                      <wired-card 
-                        style={{
-                          ...styles.saveButton,
-                          color: '#f44336'
-                        }}
-                        onClick={() => {
-                          setModalState('reset');
-                        }}
-                        elevation={2}
-                      >
-                        <Icon name="shuffle" /> Restart
-                      </wired-card>
-                    </div>
-
-                    <div style={styles.fileModalRow}>
-                      <wired-card style={styles.loadButton} onClick={() => fileInputRef.current?.click()} elevation={2}>
-                        <Icon name="display" /> Load
-                      </wired-card>
-                      <input
-                        ref={fileInputRef}
-                        type="file"
-                        accept=".html"
-                        onChange={handleFileLoad}
-                        style={styles.hiddenInput}
-                      />
-                      
-                      <wired-card 
-                        style={{ 
-                          ...styles.saveButton,
-                          cursor: deck.cards.length === 0 ? 'not-allowed' : 'pointer',
-                          opacity: deck.cards.length === 0 ? 0.5 : 1,
-                          color: deck.cards.length === 0 ? 'grey' : undefined
-                        }}
-                        onClick={deck.cards.length === 0 ? undefined : () => {
-                          setSaveFileName(deck.name || 'My Deck');
-                          setModalState('save');
-                        }}
-                        elevation={2}
-                      >
-                        <Icon name="take" /> Save
-                      </wired-card>
-                    </div>
+                    {deck.cards.length === 0 ? (
+                      <div style={styles.fileModalRow}>
+                        <wired-card style={styles.loadButton} onClick={() => fileInputRef.current?.click()} elevation={2}>
+                          <Icon name="display" /> Load
+                        </wired-card>
+                        <wired-card style={styles.saveButton} onClick={() => setModalState('closed')} elevation={2}>
+                          <Icon name="create" /> New
+                        </wired-card>
+                      </div>
+                    ) : (
+                      <>
+                        <div style={styles.fileModalRow}>
+                          <wired-card
+                            style={styles.saveButton}
+                            onClick={() => {
+                              if (confirm('Any unsaved changes will be lost. Are you sure you want to leave?')) {
+                                navigate('/');
+                              }
+                            }}
+                            elevation={2}
+                          >
+                            <Icon name="copy" /> Home
+                          </wired-card>
+                          <wired-card
+                            style={{ ...styles.saveButton, color: '#f44336' }}
+                            onClick={() => setModalState('reset')}
+                            elevation={2}
+                          >
+                            <Icon name="shuffle" /> Restart
+                          </wired-card>
+                        </div>
+                        <div style={styles.fileModalRow}>
+                          <wired-card style={styles.loadButton} onClick={() => fileInputRef.current?.click()} elevation={2}>
+                            <Icon name="display" /> Load
+                          </wired-card>
+                          <wired-card
+                            style={styles.saveButton}
+                            onClick={() => {
+                              setSaveFileName(deck.name || 'My Deck');
+                              setModalState('save');
+                            }}
+                            elevation={2}
+                          >
+                            <Icon name="take" /> Save
+                          </wired-card>
+                        </div>
+                        <wired-card style={{ ...styles.saveButton, width: '100%' }} onClick={() => setModalState('closed')} elevation={2}>
+                          <Icon name="exit" /> Close
+                        </wired-card>
+                      </>
+                    )}
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      accept=".html"
+                      onChange={handleFileLoad}
+                      style={styles.hiddenInput}
+                    />
                   </div>
                 </>
               )}

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -83,8 +83,9 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
       transform: 'translateX(-50%)',
       zIndex: 10,
       display: 'flex',
-      gap: '1em',
-      justifyContent: 'center'
+      justifyContent: 'space-around',
+      width: '100%',
+      maxWidth: '40em',
     },
     bottomRow: {
       position: 'fixed' as const,
@@ -93,8 +94,9 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
       transform: 'translateX(-50%)',
       zIndex: 10,
       display: 'flex',
-      gap: '1em',
-      justifyContent: 'center'
+      justifyContent: 'space-around',
+      width: '100%',
+      maxWidth: '40em',
     },
     button: {
       cursor: 'pointer',

--- a/src/Components/Icons.tsx
+++ b/src/Components/Icons.tsx
@@ -1,8 +1,11 @@
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import AdjustIcon from '@mui/icons-material/Adjust';
 import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
 import GrainIcon from '@mui/icons-material/Grain';
+import LensIcon from '@mui/icons-material/Lens';
+import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
 import BackHandOutlinedIcon from '@mui/icons-material/BackHandOutlined';
 import BookOutlinedIcon from '@mui/icons-material/BookOutlined';
 import BuildOutlinedIcon from '@mui/icons-material/BuildOutlined';
@@ -93,6 +96,9 @@ type IconName =
   'view_module' |
   'show' |
   'hide' |
+  'size_sm' |
+  'size_md' |
+  'size_lg' |
   'solid' |
   'stipple' |
   'wand' |
@@ -145,6 +151,9 @@ export function Icon(props: { name: IconName }) {
     stop: <StopIcon></StopIcon>,
     show: <VisibilityIcon></VisibilityIcon>,
     hide: <VisibilityOffIcon></VisibilityOffIcon>,
+    size_sm: <RadioButtonUncheckedIcon></RadioButtonUncheckedIcon>,
+    size_md: <AdjustIcon></AdjustIcon>,
+    size_lg: <LensIcon></LensIcon>,
     solid: <FiberManualRecordIcon></FiberManualRecordIcon>,
     stipple: <GrainIcon></GrainIcon>,
     wand: <AutoFixHighIcon></AutoFixHighIcon>,

--- a/src/Components/Icons.tsx
+++ b/src/Components/Icons.tsx
@@ -1,7 +1,6 @@
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
-import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
 import GrainIcon from '@mui/icons-material/Grain';
 import BackHandOutlinedIcon from '@mui/icons-material/BackHandOutlined';
 import BookOutlinedIcon from '@mui/icons-material/BookOutlined';
@@ -145,7 +144,7 @@ export function Icon(props: { name: IconName }) {
     stop: <StopIcon></StopIcon>,
     show: <VisibilityIcon></VisibilityIcon>,
     hide: <VisibilityOffIcon></VisibilityOffIcon>,
-    solid: <FiberManualRecordIcon></FiberManualRecordIcon>,
+    solid: <StopIcon></StopIcon>,
     stipple: <GrainIcon></GrainIcon>,
     wand: <AutoFixHighIcon></AutoFixHighIcon>,
     weight: <LineWeightSharpIcon></LineWeightSharpIcon>,

--- a/src/Components/Icons.tsx
+++ b/src/Components/Icons.tsx
@@ -3,10 +3,6 @@ import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
 import GrainIcon from '@mui/icons-material/Grain';
-import SignalCellular0BarIcon from '@mui/icons-material/SignalCellular0Bar';
-import SignalCellular1BarIcon from '@mui/icons-material/SignalCellular1Bar';
-import SignalCellular2BarIcon from '@mui/icons-material/SignalCellular2Bar';
-import SignalCellular4BarIcon from '@mui/icons-material/SignalCellular4Bar';
 import BackHandOutlinedIcon from '@mui/icons-material/BackHandOutlined';
 import BookOutlinedIcon from '@mui/icons-material/BookOutlined';
 import BuildOutlinedIcon from '@mui/icons-material/BuildOutlined';
@@ -97,9 +93,6 @@ type IconName =
   'view_module' |
   'show' |
   'hide' |
-  'size_sm' |
-  'size_md' |
-  'size_lg' |
   'solid' |
   'stipple' |
   'wand' |
@@ -152,9 +145,6 @@ export function Icon(props: { name: IconName }) {
     stop: <StopIcon></StopIcon>,
     show: <VisibilityIcon></VisibilityIcon>,
     hide: <VisibilityOffIcon></VisibilityOffIcon>,
-    size_sm: <SignalCellular0BarIcon></SignalCellular0BarIcon>,
-    size_md: <SignalCellular2BarIcon></SignalCellular2BarIcon>,
-    size_lg: <SignalCellular4BarIcon></SignalCellular4BarIcon>,
     solid: <FiberManualRecordIcon></FiberManualRecordIcon>,
     stipple: <GrainIcon></GrainIcon>,
     wand: <AutoFixHighIcon></AutoFixHighIcon>,

--- a/src/Components/Icons.tsx
+++ b/src/Components/Icons.tsx
@@ -1,11 +1,11 @@
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
-import AdjustIcon from '@mui/icons-material/Adjust';
 import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
 import GrainIcon from '@mui/icons-material/Grain';
-import LensIcon from '@mui/icons-material/Lens';
-import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
+import SignalCellular1BarIcon from '@mui/icons-material/SignalCellular1Bar';
+import SignalCellular2BarIcon from '@mui/icons-material/SignalCellular2Bar';
+import SignalCellular4BarIcon from '@mui/icons-material/SignalCellular4Bar';
 import BackHandOutlinedIcon from '@mui/icons-material/BackHandOutlined';
 import BookOutlinedIcon from '@mui/icons-material/BookOutlined';
 import BuildOutlinedIcon from '@mui/icons-material/BuildOutlined';
@@ -151,9 +151,9 @@ export function Icon(props: { name: IconName }) {
     stop: <StopIcon></StopIcon>,
     show: <VisibilityIcon></VisibilityIcon>,
     hide: <VisibilityOffIcon></VisibilityOffIcon>,
-    size_sm: <RadioButtonUncheckedIcon></RadioButtonUncheckedIcon>,
-    size_md: <AdjustIcon></AdjustIcon>,
-    size_lg: <LensIcon></LensIcon>,
+    size_sm: <SignalCellular1BarIcon></SignalCellular1BarIcon>,
+    size_md: <SignalCellular2BarIcon></SignalCellular2BarIcon>,
+    size_lg: <SignalCellular4BarIcon></SignalCellular4BarIcon>,
     solid: <FiberManualRecordIcon></FiberManualRecordIcon>,
     stipple: <GrainIcon></GrainIcon>,
     wand: <AutoFixHighIcon></AutoFixHighIcon>,

--- a/src/Components/Icons.tsx
+++ b/src/Components/Icons.tsx
@@ -3,6 +3,7 @@ import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
 import GrainIcon from '@mui/icons-material/Grain';
+import SignalCellular0BarIcon from '@mui/icons-material/SignalCellular0Bar';
 import SignalCellular1BarIcon from '@mui/icons-material/SignalCellular1Bar';
 import SignalCellular2BarIcon from '@mui/icons-material/SignalCellular2Bar';
 import SignalCellular4BarIcon from '@mui/icons-material/SignalCellular4Bar';
@@ -151,7 +152,7 @@ export function Icon(props: { name: IconName }) {
     stop: <StopIcon></StopIcon>,
     show: <VisibilityIcon></VisibilityIcon>,
     hide: <VisibilityOffIcon></VisibilityOffIcon>,
-    size_sm: <SignalCellular1BarIcon></SignalCellular1BarIcon>,
+    size_sm: <SignalCellular0BarIcon></SignalCellular0BarIcon>,
     size_md: <SignalCellular2BarIcon></SignalCellular2BarIcon>,
     size_lg: <SignalCellular4BarIcon></SignalCellular4BarIcon>,
     solid: <FiberManualRecordIcon></FiberManualRecordIcon>,

--- a/src/Components/Icons.tsx
+++ b/src/Components/Icons.tsx
@@ -1,6 +1,7 @@
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import GrainIcon from '@mui/icons-material/Grain';
 import BackHandOutlinedIcon from '@mui/icons-material/BackHandOutlined';
 import BookOutlinedIcon from '@mui/icons-material/BookOutlined';
 import BuildOutlinedIcon from '@mui/icons-material/BuildOutlined';
@@ -91,6 +92,7 @@ type IconName =
   'view_module' |
   'show' |
   'hide' |
+  'stipple' |
   'wand' |
   'weight';
 
@@ -141,6 +143,7 @@ export function Icon(props: { name: IconName }) {
     stop: <StopIcon></StopIcon>,
     show: <VisibilityIcon></VisibilityIcon>,
     hide: <VisibilityOffIcon></VisibilityOffIcon>,
+    stipple: <GrainIcon></GrainIcon>,
     wand: <AutoFixHighIcon></AutoFixHighIcon>,
     weight: <LineWeightSharpIcon></LineWeightSharpIcon>,
   }

--- a/src/Components/Icons.tsx
+++ b/src/Components/Icons.tsx
@@ -1,6 +1,7 @@
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
 import GrainIcon from '@mui/icons-material/Grain';
 import BackHandOutlinedIcon from '@mui/icons-material/BackHandOutlined';
 import BookOutlinedIcon from '@mui/icons-material/BookOutlined';
@@ -92,6 +93,7 @@ type IconName =
   'view_module' |
   'show' |
   'hide' |
+  'solid' |
   'stipple' |
   'wand' |
   'weight';
@@ -143,6 +145,7 @@ export function Icon(props: { name: IconName }) {
     stop: <StopIcon></StopIcon>,
     show: <VisibilityIcon></VisibilityIcon>,
     hide: <VisibilityOffIcon></VisibilityOffIcon>,
+    solid: <FiberManualRecordIcon></FiberManualRecordIcon>,
     stipple: <GrainIcon></GrainIcon>,
     wand: <AutoFixHighIcon></AutoFixHighIcon>,
     weight: <LineWeightSharpIcon></LineWeightSharpIcon>,


### PR DESCRIPTION
## Summary

- Adds a stipple brush mode to simulate grayscale shading within the 1-bit constraint
- Dots are plotted at varying densities along the stroke path using Atrament's `MODE_DISABLED` (so input smoothing and stroke recording work unchanged)
- Three density presets: Light (radius 1, spacing 8), Medium (radius 1.5, spacing 4), Dark (radius 2, spacing 2)
- Undo/redo fully supported — stipple strokes are replayed by re-plotting dots from recorded segments
- Stipple and eraser modes are mutually exclusive in the deck editor

## Changes

- **`Canvas.js`** — core stipple logic: `segmentdrawn` listener plots dots, `strokerecorded` tags stipple strokes, undo/redo replay handles `isStipple` flag; exports `cycleStippleDensity`, `getStippleDensity`, `resetStipple`
- **`ActionSpace.tsx`** — Stipple button added to `create-sketch` toolbar (cycles off → Light → Medium → Dark → off), resets when leaving sketch mode
- **`DeckEditor.tsx`** — Stipple button added to `DrawingControls` top row alongside Size and Erase; activating one deactivates the other

## Test plan

- [ ] Draw with stipple at each density (Light, Medium, Dark) in both the game board and deck editor
- [ ] Verify undo removes stipple dots correctly and redo restores them
- [ ] Verify stipple resets when closing the sketchpad
- [ ] Verify stipple and eraser are mutually exclusive in the deck editor
- [ ] Confirm exported card images look correct (pure black dots, no gray pixels)

Closes BWC-5