### PR TITLE
refactor: expose MODE_DOTS as first-class drawing mode (BWC-6)

### DIFF
--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -1,8 +1,9 @@
 // HTML Canvas: https://github.com/jakubfiala/atrament
 import Atrament, { MODE_DRAW, MODE_ERASE, MODE_DISABLED } from 'atrament';
 
-// Re-export mode constants
+// Re-export atrament mode constants plus our logical dots mode
 export { MODE_DRAW, MODE_ERASE };
+export const MODE_DOTS = 'dots';
 
 const vw = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0)
 const vh = Math.max(document.documentElement.clientHeight || 0, window.innerHeight || 0)
@@ -27,6 +28,19 @@ export const strokes = [];
 export const redoStack = [];
 let isUndoRedoInProgress = false;
 
+// Drawing mode state machine (managed across Canvas.js + ActionSpace.tsx):
+//
+//   SOLID  + Erase → ERASE   (activate erase)
+//   ERASE  + Erase → SOLID   (deactivate erase)
+//   SOLID  + Dots  → DOTS    (activate stipple)
+//   DOTS   + Dots  → SOLID   (deactivate stipple)
+//   DOTS   + Erase → ERASE   (setMode clears stipple state before activating erase)
+//   ERASE  + Dots  → DOTS    (setMode clears erase before activating stipple)
+//
+// setMode/getMode translate between the logical modes (MODE_DRAW/ERASE/DOTS) and the
+// atrament internal state (MODE_DRAW/ERASE/MODE_DISABLED + stippleDensity).
+// React components mirror the logical mode in a single drawMode state variable.
+
 // Stipple mode — plots dots at varying density to simulate shading within the 1-bit constraint.
 // NOTE: segmentdrawn only fires inside Atrament's draw(), which is skipped in MODE_DISABLED.
 // We track pointer events directly and use distance-based dot spacing instead.
@@ -44,6 +58,7 @@ let stippleDistSinceDot = 0;
 
 function plotDot(x, y) {
   const ctx = canvas.getContext('2d');
+  ctx.globalCompositeOperation = 'source-over';
   ctx.fillStyle = 'black';
   ctx.beginPath();
   ctx.arc(x, y, sketchpad.weight / 2, 0, Math.PI * 2);
@@ -126,6 +141,7 @@ function replayStippleStroke(stroke) {
   if (!ctx) return;
   const radius = (stroke.weight ?? 4) / 2;
   const { spacing } = STIPPLE_PRESETS[stroke.stippleDensity];
+  ctx.globalCompositeOperation = 'source-over';
   ctx.fillStyle = 'black';
   let lastPoint = null;
   let distSinceDot = 0;
@@ -157,7 +173,7 @@ export const undo = (baseImage = null) => {
 
   // Store original brush settings
   const original = {
-    mode: sketchpad.mode,
+    mode: getMode(),
     weight: sketchpad.weight,
     smoothing: sketchpad.smoothing,
     color: sketchpad.color,
@@ -236,7 +252,7 @@ export const undo = (baseImage = null) => {
   // Restore original brush settings
   // timeout because it breaks without?!
   setTimeout(() => {
-    sketchpad.mode = original.mode;
+    setMode(original.mode);
     isUndoRedoInProgress = false;
   }, 100);
   sketchpad.weight = original.weight;
@@ -255,7 +271,7 @@ export const redo = (baseImage = null) => {
 
   // Store original brush settings
   const original = {
-    mode: sketchpad.mode,
+    mode: getMode(),
     weight: sketchpad.weight,
     smoothing: sketchpad.smoothing,
     color: sketchpad.color,
@@ -359,7 +375,7 @@ export const redo = (baseImage = null) => {
 
   // Restore original brush settings
   setTimeout(() => {
-    sketchpad.mode = original.mode;
+    setMode(original.mode);
     isUndoRedoInProgress = false;
   }, 100);
   sketchpad.weight = original.weight;
@@ -369,12 +385,22 @@ export const redo = (baseImage = null) => {
 }
 
 export const setMode = (mode) => {
-  sketchpad.mode = mode;
-}
+  if (mode === MODE_DOTS) {
+    stippleDensity = 'light';
+    sketchpad.mode = MODE_DISABLED;
+  } else {
+    stippleDensity = null;
+    stippleActive = false;
+    stippleSegments = [];
+    stippleLastPoint = null;
+    stippleDistSinceDot = 0;
+    sketchpad.mode = mode;
+  }
+};
 
 export const getMode = () => {
-  return sketchpad.mode;
-}
+  return stippleDensity ? MODE_DOTS : sketchpad.mode;
+};
 
 export const fillWhite = () => {
   const fillCanvas = document.getElementById("sketchpad");
@@ -407,8 +433,10 @@ export const fillWhite = () => {
   });
   redoStack.length = 0;
 
-  // Stay in draw mode
-  sketchpad.mode = MODE_DRAW;
+  // Preserve MODE_DISABLED (stipple) but reset erase mode
+  if (sketchpad.mode !== MODE_DISABLED) {
+    sketchpad.mode = MODE_DRAW;
+  }
   sketchpad.color = originalColor;
   sketchpad.weight = originalWeight;
 }
@@ -427,20 +455,3 @@ export const getCurrentBrushSize = () => {
   return brushSizeLabels[currentSizeIndex];
 }
 
-export const cycleStippleDensity = () => {
-  const idx = STIPPLE_DENSITIES.indexOf(stippleDensity);
-  stippleDensity = STIPPLE_DENSITIES[(idx + 1) % STIPPLE_DENSITIES.length];
-  sketchpad.mode = stippleDensity ? MODE_DISABLED : MODE_DRAW;
-  return stippleDensity;
-};
-
-export const getStippleDensity = () => stippleDensity;
-
-export const resetStipple = () => {
-  if (stippleDensity) sketchpad.mode = MODE_DRAW;
-  stippleDensity = null;
-  stippleActive = false;
-  stippleSegments = [];
-  stippleLastPoint = null;
-  stippleDistSinceDot = 0;
-};

--- a/src/Components/ActionSpace.tsx
+++ b/src/Components/ActionSpace.tsx
@@ -7,7 +7,7 @@ import { Card, getCardsByLocation, getCardsByOwner } from '../Cards';
 import { Icon } from './Icons';
 import { useState, useEffect, useContext, useRef, useCallback } from 'react';
 //@ts-expect-error: JS Module
-import { undo, redo, strokes, sketchpad, cycleStippleDensity, resetStipple, fillWhite, cycleBrushSize, getCurrentBrushSize, getMode, setMode as setCanvasMode, MODE_DRAW, MODE_ERASE } from '../Canvas.js';
+import { undo, redo, strokes, sketchpad, fillWhite, cycleBrushSize, getCurrentBrushSize, getMode, setMode as setCanvasMode, MODE_DRAW, MODE_ERASE, MODE_DOTS } from '../Canvas.js';
 import { Link, useNavigate } from 'react-router';
 import { AuthContext, FocusContext, LoadingContext } from '../lib/contexts.ts';
 import { openDeckEditor } from '../lib/data.ts';
@@ -27,8 +27,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
   const { setAuth } = useContext(AuthContext);
   const { loading, setLoading } = useContext(LoadingContext);
   const [submitStatus, setSubmitStatus] = useState('Submit');
-  const [stippleDensity, setStippleDensity] = useState<string | null>(null);
-  const [eraserActive, setEraserActive] = useState(false);
+  const [drawMode, setDrawMode] = useState<string>(MODE_DRAW);
   const [brushSize, setBrushSize] = useState('Medium');
   const { focus, setFocus } = useContext(FocusContext);
   const focusCard = useCallback(((id: number, focusState: boolean) => {
@@ -159,14 +158,10 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
   }, [setAuth, navigate])
 
   useEffect(() => {
+    setCanvasMode(MODE_DRAW);
+    setDrawMode(MODE_DRAW);
     if (mode === 'create-sketch') {
-      setCanvasMode(MODE_DRAW);
-      setEraserActive(false);
       setBrushSize(getCurrentBrushSize());
-    } else {
-      resetStipple();
-      setStippleDensity(null);
-      setEraserActive(false);
     }
   }, [mode]);
 
@@ -347,19 +342,18 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
   } else if (mode === 'create-sketch') {
     topRow = (
       <div style={{ position: 'fixed', top: 'calc(2em + 12px)', left: '50%', transform: 'translateX(-50%)', zIndex: 10, display: 'flex', justifyContent: 'space-around', width: '100%', maxWidth: '40em' }}>
-        <wired-card style={{ ...styles.button, color: 'red' }} onClick={() => { fillWhite(); setEraserActive(false); }} elevation={2}><Icon name='discard' />Clear</wired-card>
-        <wired-card style={{ ...styles.button, color: eraserActive ? 'red' : undefined }} onClick={() => {
-          const newMode = getMode() === MODE_ERASE ? MODE_DRAW : MODE_ERASE;
+        <wired-card style={{ ...styles.button, color: 'red' }} onClick={() => { fillWhite(); setDrawMode(getMode()); }} elevation={2}><Icon name='discard' />Clear</wired-card>
+        <wired-card style={{ ...styles.button, color: drawMode === MODE_ERASE ? 'red' : undefined }} onClick={() => {
+          const newMode = drawMode === MODE_ERASE ? MODE_DRAW : MODE_ERASE;
           setCanvasMode(newMode);
-          setEraserActive(newMode === MODE_ERASE);
-          if (newMode === MODE_ERASE) { resetStipple(); setStippleDensity(null); }
+          setDrawMode(newMode);
         }} elevation={2}><Icon name='wand' />Erase</wired-card>
         <wired-card style={{ ...styles.button }} onClick={() => { setBrushSize(cycleBrushSize()); }} elevation={2}><Icon name='weight' />{brushSize}</wired-card>
         <wired-card style={{ ...styles.button }} onClick={() => {
-          const next = cycleStippleDensity();
-          setStippleDensity(next);
-          if (next) setEraserActive(false);
-        }} elevation={2}><Icon name={stippleDensity ? 'stipple' : 'solid'} />{stippleDensity ? 'Dots' : 'Solid'}</wired-card>
+          const newMode = drawMode === MODE_DOTS ? MODE_DRAW : MODE_DOTS;
+          setCanvasMode(newMode);
+          setDrawMode(newMode);
+        }} elevation={2}><Icon name={drawMode === MODE_DOTS ? 'stipple' : 'solid'} />{drawMode === MODE_DOTS ? 'Dots' : 'Solid'}</wired-card>
       </div>
     );
     toolset = <>

--- a/src/Components/Editor/DeckEditor.tsx
+++ b/src/Components/Editor/DeckEditor.tsx
@@ -6,7 +6,7 @@ import { CardEditor } from './CardEditor';
 import { FullCardView, CompactCardView, ImageOnlyCardView } from './CardViews';
 import { ViewModeToggle } from './EditorControls';
 //@ts-expect-error: JS Module
-import { fillWhite, cycleBrushSize, getCurrentBrushSize, getMode, setMode, MODE_DRAW, MODE_ERASE, cycleStippleDensity, getStippleDensity, resetStipple } from '../../Canvas.js';
+import { fillWhite, cycleBrushSize, getCurrentBrushSize, getMode, setMode, MODE_DRAW, MODE_ERASE, MODE_DOTS } from '../../Canvas.js';
 
 function DrawingControls({ onBack, onUndo, onRedo, onCancel }: { 
   onBack: () => void,
@@ -14,17 +14,14 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
   onRedo: () => void,
   onCancel: () => void
 }) {
-  const [eraserActive, setEraserActive] = useState(false);
+  const [drawMode, setDrawMode] = useState<string>(MODE_DRAW);
   const [brushSize, setBrushSize] = useState('Medium');
-  const [stippleDensity, setStippleDensity] = useState<string | null>(null);
   const [handlersReady, setHandlersReady] = useState(false);
 
   // Reset to draw mode when component mounts
   useEffect(() => {
     setMode(MODE_DRAW);
-    setEraserActive(false);
-    resetStipple();
-    setStippleDensity(null);
+    setDrawMode(MODE_DRAW);
     setBrushSize(getCurrentBrushSize());
   }, []);
 
@@ -34,23 +31,15 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
   }, [onBack, onCancel]);
 
   const handleEraserToggle = () => {
-    const newMode = getMode() === MODE_ERASE ? MODE_DRAW : MODE_ERASE;
+    const newMode = drawMode === MODE_ERASE ? MODE_DRAW : MODE_ERASE;
     setMode(newMode);
-    setEraserActive(newMode === MODE_ERASE);
-    // Deactivate stipple when switching to eraser
-    if (newMode === MODE_ERASE) {
-      resetStipple();
-      setStippleDensity(null);
-    }
+    setDrawMode(newMode);
   };
 
   const handleStippleToggle = () => {
-    const next = cycleStippleDensity();
-    setStippleDensity(next);
-    // Deactivate eraser when stipple is turned on
-    if (next) {
-      setEraserActive(false);
-    }
+    const newMode = drawMode === MODE_DOTS ? MODE_DRAW : MODE_DOTS;
+    setMode(newMode);
+    setDrawMode(newMode);
   };
 
   const handleUndo = () => {
@@ -72,7 +61,7 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
 
   const handleClear = () => {
     fillWhite();
-    setEraserActive(false);
+    setDrawMode(getMode());
   };
 
   const styles = {
@@ -122,7 +111,7 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
           elevation={2}
           style={{
             ...styles.button,
-            color: eraserActive ? 'red' : undefined
+            color: drawMode === MODE_ERASE ? 'red' : undefined
           }}
           onClick={handleEraserToggle}
         >
@@ -138,8 +127,8 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
           style={styles.button}
           onClick={handleStippleToggle}
         >
-          <Icon name={stippleDensity ? 'stipple' : 'solid'} />
-          {stippleDensity ? 'Dots' : 'Solid'}
+          <Icon name={drawMode === MODE_DOTS ? 'stipple' : 'solid'} />
+          {drawMode === MODE_DOTS ? 'Dots' : 'Solid'}
         </wired-card>
       </div>
       <div style={styles.bottomRow}>


### PR DESCRIPTION
## Summary

- Replaces the dual `stippleDensity` + `MODE_DISABLED` representation of dots mode with a single exported `MODE_DOTS` constant
- `setMode`/`getMode` in Canvas.js now own the full translation between logical modes and atrament internals — callers never touch `MODE_DISABLED` or `stippleDensity` directly
- React components (`ActionSpace`, `DeckEditor`) collapse `eraserActive: bool` + `stippleDensity: string | null` into a single `drawMode` state variable, eliminating the sync bugs at the source

## State machine

```
SOLID + Erase → ERASE
ERASE + Erase → SOLID
SOLID + Dots  → DOTS
DOTS  + Dots  → SOLID
DOTS  + Erase → ERASE
ERASE + Dots  → DOTS
```

## Fixes

- **Dotted erase bug**: `plotDot` and `replayStippleStroke` now assert `globalCompositeOperation = 'source-over'` so dots always draw regardless of what composite operation atrament left on the context
- **Undo/redo mode restore**: undo and redo now capture/restore via `getMode()`/`setMode()` so dots mode survives undo correctly (previously restored `MODE_DISABLED` without restoring `stippleDensity`)
- Removes `cycleStippleDensity`, `resetStipple`, `getStippleDensity` exports — all mode transitions go through `setMode`

## Test plan

- [ ] Solid → Erase → Solid toggle works
- [ ] Solid → Dots → Solid toggle works
- [ ] Dots → Erase transitions to erase (not dotted erase)
- [ ] Erase → Dots transitions to dots
- [ ] Undo/redo preserves current mode
- [ ] Clear preserves dots mode, resets erase mode
- [ ] All of the above work identically in the Deck Editor

Closes BWC-6