### PR TITLE
feat: game scoring system (BWC-9)

### DIFF
--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -9,7 +9,9 @@ interface CalculatorProps {
   label?: string;
 }
 
-// Safely evaluate a math expression string
+// Safely evaluate a math expression string.
+// new Function is intentional here — scores are set by players for themselves,
+// so the eval surface is limited to the expression the player typed in their own session.
 const evalExpr = (expr: string): number | null => {
   try {
     // Replace display chars with JS operators, and strip leading zeros that cause octal

--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -73,12 +73,12 @@ export function Calculator({ initialValue, onConfirm, onCancel, label }: Calcula
     <wired-dialog open onClick={sp}>
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0, padding: '0.5em 0.75em 0.75em' }}>
         {/* Display */}
-        <wired-card style={{ width: '100%', marginBottom: '0.1em', cursor: 'default' } as CSSProperties}
+        <wired-card style={{ width: '17em', margin: '0.5em 0', cursor: 'default' } as CSSProperties}
           onClick={(e) => e.stopPropagation()}
         >
-          <div style={{ display: 'flex', alignItems: 'center', fontFamily: 'monospace', gap: '0.4em', minHeight: '1em', padding: '0.1em 0.2em' }}>
-            {label && <span style={{ color: '#888', flexShrink: 0, fontSize: '0.8em' }}>{label}</span>}
-            <span style={{ flex: 1, textAlign: 'right', overflowX: 'auto', whiteSpace: 'nowrap' }}>{expr}</span>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontFamily: 'monospace', fontSize: '1.5em', minHeight: '2.25em', padding: '0 0.25em' }}>
+            {label && <span style={{ color: '#888', fontSize: '0.8em' }}>{label}</span>}
+            <span style={{ textAlign: 'right', maxWidth: '9.5em', overflowX: 'hidden' }}>{expr}</span>
           </div>
         </wired-card>
         {/* Row 1: ⌫ | C | ^ | ÷ */}

--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -31,7 +31,7 @@ export const formatScore = (n: number): string => {
   const abs = Math.abs(n);
   const sign = n < 0 ? '-' : '';
   if (abs < 1e5) {
-    if (abs > 0 && abs < 0.01) return `${sign}<0.01`;
+    if (abs > 0 && abs < 0.01) return n < 0 ? '>-0.01' : '<0.01';
     const s = parseFloat(n.toPrecision(4));
     return String(s);
   }

--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -27,6 +27,21 @@ const evalExpr = (expr: string): number | null => {
 
 const OPS = new Set(['+', '-', '*', '/', '×', '÷', '−', '^']);
 
+export const formatScore = (n: number): string => {
+  const abs = Math.abs(n);
+  const sign = n < 0 ? '-' : '';
+  if (abs < 1e5) return String(n);
+  const fmt = (val: number, suffix: string) => {
+    const floored = Math.floor(val * 100) / 100;
+    return `${sign}${floored.toFixed(2).replace(/\.?0+$/, '')}${suffix}`;
+  };
+  if (abs < 1e6) return `${sign}${Math.floor(abs / 1e3)}k`;
+  if (abs < 1e9) return fmt(abs / 1e6, 'M');
+  if (abs < 1e12) return fmt(abs / 1e9, 'G');
+  if (abs < 1e15) return fmt(abs / 1e12, 'T');
+  return `${sign}${abs.toExponential(3).replace('e+', ' e').replace('e-', ' e-').replace('e', ' e')}`;
+};
+
 export function Calculator({ initialValue, onConfirm, onCancel, label }: CalculatorProps) {
   const [expr, setExpr] = useState(String(initialValue));
 

--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -16,7 +16,7 @@ const evalExpr = (expr: string): number | null => {
     const js = expr
       .replace(/×/g, '*').replace(/÷/g, '/').replace(/\u2212/g, '-')
       .replace(/\^/g, '**') // exponentiation
-      .replace(/\b0+(?=[1-9])/g, ''); // strip leading zeros (not before decimal point)
+      .replace(/(?<![.\d])0+(?=[1-9])/g, ''); // strip leading zeros on integers only
     // eslint-disable-next-line no-new-func
     const result = new Function(`return (${js})`)();
     return typeof result === 'number' && isFinite(result) ? result : null;

--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -49,7 +49,7 @@ export function Calculator({ initialValue, onConfirm, onCancel, label }: Calcula
   };
 
   const backspace = () => setExpr(prev => prev.length > 1 ? prev.slice(0, -1) : '0');
-  const dispRef = useRef<HTMLDivElement>(null);
+  const dispRef = useRef<HTMLElement>(null);
   useEffect(() => { dispRef.current?.focus(); }, []);
   const parsed = evalExpr(expr);
   const valid = parsed !== null;
@@ -57,26 +57,24 @@ export function Calculator({ initialValue, onConfirm, onCancel, label }: Calcula
   const sp = (e: { stopPropagation: () => void }) => e.stopPropagation();
 
   const base: CSSProperties = {
-    height: '3em', width: '3em', margin: '0.15em',
-    fontWeight: 'bold', fontSize: '1em', textAlign: 'center',
+    height: '2em', width: '2em', margin: '0.1em',
+    fontWeight: 'bold', fontSize: '1.5em', textAlign: 'center',
     display: 'flex', justifyContent: 'center', alignItems: 'center',
     cursor: 'pointer', borderRadius: '0.3em', userSelect: 'none',
   };
-  const numBtn: CSSProperties = { ...base, backgroundColor: '#eee' };  // digits + .
-  const opBtn: CSSProperties = { ...base, backgroundColor: '#ddd' };   // + - × ÷ ^ =
-  const funcBtn: CSSProperties = { ...base, backgroundColor: '#ccc' }; // ⌫ C
+  const numBtn: CSSProperties = { ...base, backgroundColor: '#e8e8e8' };
+  const opBtn: CSSProperties = { ...base, backgroundColor: '#e8e8e8' };
+  const funcBtn: CSSProperties = { ...base, backgroundColor: '#e8e8e8' };
   const confirmBtn: CSSProperties = { ...base, backgroundColor: '#ccc' };
   const cancelBtn: CSSProperties = { ...base, backgroundColor: '#ccc', color: '#c00' };
 
   return (
     <wired-dialog open onClick={sp}>
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0, padding: '0.5em 0.75em 0.75em' }}>
-        {label && <div style={{ fontWeight: 'bold', fontSize: '0.85em', marginBottom: '0.3em' }}>{label}</div>}
-        {/* Expression display */}
-        <wired-card
+        {/* Display */}
+        <wired-card style={{ width: '100%', marginBottom: '0.1em', cursor: 'default', outline: 'none', tabIndex: 0, fontSize: '1.5em' } as CSSProperties}
           tabIndex={0}
           ref={dispRef as React.Ref<HTMLElement>}
-          style={{ width: '100%', fontSize: '1.3em', textAlign: 'right', padding: '0.5em 0.6em', marginBottom: '0.3em', fontFamily: 'monospace', minHeight: '2.8em', outline: 'none', cursor: 'default', userSelect: 'text', display: 'block', boxSizing: 'border-box' } as CSSProperties}
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e: React.KeyboardEvent) => {
             if (/^[0-9]$/.test(e.key)) { append(e.key); return; }
@@ -92,7 +90,10 @@ export function Calculator({ initialValue, onConfirm, onCancel, label }: Calcula
             if (e.key === 'Delete') { clear(); return; }
           }}
         >
-          {expr}
+          <div style={{ display: 'flex', alignItems: 'center', fontFamily: 'monospace', gap: '0.4em', minHeight: '1em', padding: '0.1em 0.2em' }}>
+            {label && <span style={{ color: '#888', flexShrink: 0, fontSize: '0.8em' }}>{label}</span>}
+            <span style={{ flex: 1, textAlign: 'right', overflowX: 'auto', whiteSpace: 'nowrap' }}>{expr}</span>
+          </div>
         </wired-card>
         {/* Row 1: ⌫ | C | ^ | ÷ */}
         <div style={{ display: 'flex' }}>
@@ -124,11 +125,11 @@ export function Calculator({ initialValue, onConfirm, onCancel, label }: Calcula
         </div>
         {/* Row 6: Cancel (half) | Done (half) */}
         <div style={{ display: 'flex', width: '100%', gap: 0 }}>
-          <wired-card style={{ ...cancelBtn, flex: 1, height: '3.5em' }} onClick={() => onCancel()}>
-            <Icon name='exit' />&nbsp;Cancel
+          <wired-card style={{ ...cancelBtn, flex: 1 }} onClick={() => onCancel()}>
+            <Icon name='exit' />
           </wired-card>
-          <wired-card style={{ ...confirmBtn, flex: 1, height: '3.5em' }} onClick={() => { if (valid && parsed !== null) onConfirm(parsed); }}>
-            <Icon name='done' />&nbsp;Set
+          <wired-card style={{ ...confirmBtn, flex: 1 }} onClick={() => { if (valid && parsed !== null) onConfirm(parsed); }}>
+            <Icon name='done' />
           </wired-card>
         </div>
       </div>

--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -188,7 +188,7 @@ export function Calculator({ initialValue, onConfirm, onCancel, label }: Calcula
           <wired-card style={{ ...cancelBtn, flex: 1 }} onClick={() => onCancel()}>
             <Icon name='exit' />
           </wired-card>
-          <wired-card style={{ ...confirmBtn, flex: 1 }} onClick={() => { if (valid && parsed !== null) onConfirm(parsed); }}>
+          <wired-card style={{ ...confirmBtn, flex: 1 }} onClick={() => { if (valid) onConfirm(parsed!); }}>
             <Icon name='done' />
           </wired-card>
         </div>

--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -16,7 +16,7 @@ const evalExpr = (expr: string): number | null => {
     const js = expr
       .replace(/×/g, '*').replace(/÷/g, '/').replace(/\u2212/g, '-')
       .replace(/\^/g, '**') // exponentiation
-      .replace(/\b0+(\d)/g, '$1'); // strip leading zeros from number literals
+      .replace(/\b0+(?=[1-9])/g, ''); // strip leading zeros (not before decimal point)
     // eslint-disable-next-line no-new-func
     const result = new Function(`return (${js})`)();
     return typeof result === 'number' && isFinite(result) ? result : null;

--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -30,7 +30,11 @@ const OPS = new Set(['+', '-', '*', '/', '×', '÷', '−', '^']);
 export const formatScore = (n: number): string => {
   const abs = Math.abs(n);
   const sign = n < 0 ? '-' : '';
-  if (abs < 1e5) return String(n);
+  if (abs < 1e5) {
+    // Cap to 4 sig figs for small values
+    const s = parseFloat(n.toPrecision(4));
+    return String(s);
+  }
   const fmt = (val: number, suffix: string) => {
     const floored = Math.floor(val * 100) / 100;
     return `${sign}${floored.toFixed(2).replace(/\.?0+$/, '')}${suffix}`;

--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState } from 'react';
 import type { CSSProperties } from 'react';
 import { Icon } from './Icons';
 
@@ -49,8 +49,6 @@ export function Calculator({ initialValue, onConfirm, onCancel, label }: Calcula
   };
 
   const backspace = () => setExpr(prev => prev.length > 1 ? prev.slice(0, -1) : '0');
-  const dispRef = useRef<HTMLElement>(null);
-  useEffect(() => { dispRef.current?.focus(); }, []);
   const parsed = evalExpr(expr);
   const valid = parsed !== null;
 
@@ -72,23 +70,8 @@ export function Calculator({ initialValue, onConfirm, onCancel, label }: Calcula
     <wired-dialog open onClick={sp}>
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0, padding: '0.5em 0.75em 0.75em' }}>
         {/* Display */}
-        <wired-card style={{ width: '100%', marginBottom: '0.1em', cursor: 'default', outline: 'none', tabIndex: 0, fontSize: '1.5em' } as CSSProperties}
-          tabIndex={0}
-          ref={dispRef as React.Ref<HTMLElement>}
+        <wired-card style={{ width: '100%', marginBottom: '0.1em', cursor: 'default' } as CSSProperties}
           onClick={(e) => e.stopPropagation()}
-          onKeyDown={(e: React.KeyboardEvent) => {
-            if (/^[0-9]$/.test(e.key)) { append(e.key); return; }
-            if (e.key === '+') { append('+'); return; }
-            if (e.key === '-') { append('−'); return; }
-            if (e.key === '*') { append('×'); return; }
-            if (e.key === '/') { e.preventDefault(); append('÷'); return; }
-            if (e.key === '.') { append('.'); return; }
-            if (e.key === '(' || e.key === ')') { append(e.key); return; }
-            if (e.key === 'Backspace') { backspace(); return; }
-            if (e.key === 'Escape') { onCancel(); return; }
-            if (e.key === 'Enter') { evaluate(); return; }
-            if (e.key === 'Delete') { clear(); return; }
-          }}
         >
           <div style={{ display: 'flex', alignItems: 'center', fontFamily: 'monospace', gap: '0.4em', minHeight: '1em', padding: '0.1em 0.2em' }}>
             {label && <span style={{ color: '#888', flexShrink: 0, fontSize: '0.8em' }}>{label}</span>}

--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -64,10 +64,7 @@ export function Calculator({ initialValue, onConfirm, onCancel, label }: Calcula
 
   const evaluate = () => {
     const result = evalExpr(expr);
-    if (result !== null) {
-      const s = String(result);
-      setExpr(s.length > 9 ? formatScore(result) : s);
-    }
+    if (result !== null) setExpr(String(result));
   };
 
   const backspace = () => setExpr(prev => prev.length > 1 ? prev.slice(0, -1) : '0');

--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -2,22 +2,6 @@ import { useState } from 'react';
 import type { CSSProperties } from 'react';
 import { Icon } from './Icons';
 
-// Format a score for display — raw up to 99,999, then SI prefixes (truncated), then scientific
-export const formatScore = (n: number): string => {
-  const abs = Math.abs(n);
-  const sign = n < 0 ? '-' : '';
-  if (abs < 1e5) return String(n);
-  const fmt = (val: number, suffix: string) => {
-    const floored = Math.floor(val * 100) / 100;
-    return `${sign}${floored.toFixed(2).replace(/\.?0+$/, '')}${suffix}`;
-  };
-  if (abs < 1e6) return `${sign}${Math.floor(abs / 1e3)}k`;
-  if (abs < 1e9) return fmt(abs / 1e6, 'M');
-  if (abs < 1e12) return fmt(abs / 1e9, 'G');
-  if (abs < 1e15) return fmt(abs / 1e12, 'T');
-  return `${sign}${abs.toExponential(3).replace('e+', ' e').replace('e-', ' e-').replace('e', ' e')}`;
-};
-
 interface CalculatorProps {
   initialValue: number;
   onConfirm: (value: number) => void;

--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -31,7 +31,7 @@ export const formatScore = (n: number): string => {
   const abs = Math.abs(n);
   const sign = n < 0 ? '-' : '';
   if (abs < 1e5) {
-    // Cap to 4 sig figs for small values
+    if (abs > 0 && abs < 0.01) return `${sign}<0.01`;
     const s = parseFloat(n.toPrecision(4));
     return String(s);
   }

--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -9,19 +9,73 @@ interface CalculatorProps {
   label?: string;
 }
 
-// Safely evaluate a math expression string.
-// new Function is intentional here — scores are set by players for themselves,
-// so the eval surface is limited to the expression the player typed in their own session.
+// Safe recursive descent parser for math expressions.
+// Supports: + - * / ** (^) with correct precedence, unary minus, parentheses, decimals.
+// No eval — only numeric literals and the operators above are accepted.
 const evalExpr = (expr: string): number | null => {
+  const js = expr.replace(/×/g, '*').replace(/÷/g, '/').replace(/\u2212/g, '-').replace(/\^/g, '**');
+  let pos = 0;
+
+  const peek = () => js[pos];
+  const consume = () => js[pos++];
+  const skipWs = () => { while (js[pos] === ' ') pos++; };
+
+  const parseNum = (): number | null => {
+    skipWs();
+    let s = '';
+    if (peek() === '-') { s += consume(); }
+    while (/[0-9.]/.test(peek() ?? '')) s += consume();
+    if (s === '' || s === '-') return null;
+    const n = parseFloat(s);
+    return isNaN(n) ? null : n;
+  };
+
+  const parseAtom = (): number | null => {
+    skipWs();
+    if (peek() === '(') {
+      consume();
+      const v = parseExpr(0);
+      skipWs();
+      if (peek() === ')') consume();
+      return v;
+    }
+    if (peek() === '-') { consume(); const v = parseAtom(); return v !== null ? -v : null; }
+    return parseNum();
+  };
+
+  type Op = { prec: number; right: boolean; fn: (a: number, b: number) => number };
+  const OPS_MAP: Record<string, Op> = {
+    '+': { prec: 1, right: false, fn: (a, b) => a + b },
+    '-': { prec: 1, right: false, fn: (a, b) => a - b },
+    '*': { prec: 2, right: false, fn: (a, b) => a * b },
+    '/': { prec: 2, right: false, fn: (a, b) => a / b },
+    '**': { prec: 3, right: true, fn: (a, b) => Math.pow(a, b) },
+  };
+
+  const parseExpr = (minPrec: number): number | null => {
+    let left = parseAtom();
+    if (left === null) return null;
+    while (true) {
+      skipWs();
+      let op = '';
+      if (js.startsWith('**', pos)) { op = '**'; }
+      else if ('+-*/'.includes(peek() ?? '')) { op = peek()!; }
+      if (!op || !OPS_MAP[op]) break;
+      const { prec, right, fn } = OPS_MAP[op];
+      if (prec < minPrec) break;
+      pos += op.length;
+      const right_val = parseExpr(right ? prec : prec + 1);
+      if (right_val === null) return null;
+      left = fn(left, right_val);
+    }
+    return left;
+  };
+
   try {
-    // Replace display chars with JS operators, and strip leading zeros that cause octal
-    const js = expr
-      .replace(/×/g, '*').replace(/÷/g, '/').replace(/\u2212/g, '-')
-      .replace(/\^/g, '**') // exponentiation
-      .replace(/(?<![.\d])0+(?=[1-9])/g, ''); // strip leading zeros on integers only
-    // eslint-disable-next-line no-new-func
-    const result = new Function(`return (${js})`)();
-    return typeof result === 'number' && isFinite(result) ? result : null;
+    const result = parseExpr(0);
+    skipWs();
+    if (pos !== js.length || result === null || !isFinite(result)) return null;
+    return result;
   } catch {
     return null;
   }

--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -1,7 +1,22 @@
 import { useState } from 'react';
 import type { CSSProperties } from 'react';
 import { Icon } from './Icons';
-import { formatScore } from './CommonSpace';
+
+// Format a score for display — raw up to 99,999, then SI prefixes (truncated), then scientific
+export const formatScore = (n: number): string => {
+  const abs = Math.abs(n);
+  const sign = n < 0 ? '-' : '';
+  if (abs < 1e5) return String(n);
+  const fmt = (val: number, suffix: string) => {
+    const floored = Math.floor(val * 100) / 100;
+    return `${sign}${floored.toFixed(2).replace(/\.?0+$/, '')}${suffix}`;
+  };
+  if (abs < 1e6) return `${sign}${Math.floor(abs / 1e3)}k`;
+  if (abs < 1e9) return fmt(abs / 1e6, 'M');
+  if (abs < 1e12) return fmt(abs / 1e9, 'G');
+  if (abs < 1e15) return fmt(abs / 1e12, 'T');
+  return `${sign}${abs.toExponential(3).replace('e+', ' e').replace('e-', ' e-').replace('e', ' e')}`;
+};
 
 interface CalculatorProps {
   initialValue: number;

--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -30,12 +30,12 @@ export function Calculator({ initialValue, onConfirm, onCancel, label }: Calcula
 
   const ops = new Set(['+', '-', '*', '/', '×', '÷', '−', '^']);
   const append = (s: string) => setExpr(prev => {
-    // Replace trailing operator with new one (unless new op is − for negation)
+    // Replace trailing operator with new one
     if (ops.has(s) && prev.length > 0 && ops.has(prev.slice(-1))) {
-      if (s === '−') return prev + s; // allow negation after operator
-      return prev.slice(0, -1) + s;  // replace same/different operator
+      if (s === '−' && prev.slice(-1) !== '−') return prev + s; // allow negation only after non-minus op
+      return prev.slice(0, -1) + s;  // replace operator (also handles −→− by replacing)
     }
-    // Block double-minus
+    // Block double-minus when not following another operator
     if (s === '−' && prev.slice(-1) === '−') return prev;
     // Replace lone '0' with digit
     if (!ops.has(s) && prev === '0') {

--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { CSSProperties } from 'react';
 import { Icon } from './Icons';
+import { formatScore } from './CommonSpace';
 
 interface CalculatorProps {
   initialValue: number;
@@ -48,7 +49,10 @@ export function Calculator({ initialValue, onConfirm, onCancel, label }: Calcula
 
   const evaluate = () => {
     const result = evalExpr(expr);
-    if (result !== null) setExpr(String(result));
+    if (result !== null) {
+      const s = String(result);
+      setExpr(s.length > 9 ? formatScore(result) : s);
+    }
   };
 
   const backspace = () => setExpr(prev => prev.length > 1 ? prev.slice(0, -1) : '0');

--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -30,10 +30,13 @@ export function Calculator({ initialValue, onConfirm, onCancel, label }: Calcula
 
   const ops = new Set(['+', '-', '*', '/', '×', '÷', '−', '^']);
   const append = (s: string) => setExpr(prev => {
-    // Replace trailing operator with new one
+    // Replace trailing operator with new one (unless new op is − for negation)
     if (ops.has(s) && prev.length > 0 && ops.has(prev.slice(-1))) {
-      return prev.slice(0, -1) + s;
+      if (s === '−') return prev + s; // allow negation after operator
+      return prev.slice(0, -1) + s;  // replace same/different operator
     }
+    // Block double-minus
+    if (s === '−' && prev.slice(-1) === '−') return prev;
     // Replace lone '0' with digit
     if (!ops.has(s) && prev === '0') {
       return s;

--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -35,7 +35,7 @@ export const formatScore = (n: number): string => {
     const floored = Math.floor(val * 100) / 100;
     return `${sign}${floored.toFixed(2).replace(/\.?0+$/, '')}${suffix}`;
   };
-  if (abs < 1e6) return `${sign}${Math.floor(abs / 1e3)}k`;
+  if (abs < 1e6) return fmt(abs / 1e3, 'k');
   if (abs < 1e9) return fmt(abs / 1e6, 'M');
   if (abs < 1e12) return fmt(abs / 1e9, 'G');
   if (abs < 1e15) return fmt(abs / 1e12, 'T');

--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -1,0 +1,137 @@
+import { useState, useEffect, useRef } from 'react';
+import type { CSSProperties } from 'react';
+import { Icon } from './Icons';
+
+interface CalculatorProps {
+  initialValue: number;
+  onConfirm: (value: number) => void;
+  onCancel: () => void;
+  label?: string;
+}
+
+// Safely evaluate a math expression string
+const evalExpr = (expr: string): number | null => {
+  try {
+    // Replace display chars with JS operators, and strip leading zeros that cause octal
+    const js = expr
+      .replace(/×/g, '*').replace(/÷/g, '/').replace(/\u2212/g, '-')
+      .replace(/\^/g, '**') // exponentiation
+      .replace(/\b0+(\d)/g, '$1'); // strip leading zeros from number literals
+    // eslint-disable-next-line no-new-func
+    const result = new Function(`return (${js})`)();
+    return typeof result === 'number' && isFinite(result) ? result : null;
+  } catch {
+    return null;
+  }
+};
+
+export function Calculator({ initialValue, onConfirm, onCancel, label }: CalculatorProps) {
+  const [expr, setExpr] = useState(String(initialValue));
+
+  const ops = new Set(['+', '-', '*', '/', '×', '÷', '−', '^']);
+  const append = (s: string) => setExpr(prev => {
+    // Replace trailing operator with new one
+    if (ops.has(s) && prev.length > 0 && ops.has(prev.slice(-1))) {
+      return prev.slice(0, -1) + s;
+    }
+    // Replace lone '0' with digit
+    if (!ops.has(s) && prev === '0') {
+      return s;
+    }
+    return prev + s;
+  });
+
+  const clear = () => setExpr('0');
+
+  const evaluate = () => {
+    const result = evalExpr(expr);
+    if (result !== null) setExpr(String(result));
+  };
+
+  const backspace = () => setExpr(prev => prev.length > 1 ? prev.slice(0, -1) : '0');
+  const dispRef = useRef<HTMLDivElement>(null);
+  useEffect(() => { dispRef.current?.focus(); }, []);
+  const parsed = evalExpr(expr);
+  const valid = parsed !== null;
+
+  const sp = (e: { stopPropagation: () => void }) => e.stopPropagation();
+
+  const base: CSSProperties = {
+    height: '3em', width: '3em', margin: '0.15em',
+    fontWeight: 'bold', fontSize: '1em', textAlign: 'center',
+    display: 'flex', justifyContent: 'center', alignItems: 'center',
+    cursor: 'pointer', borderRadius: '0.3em', userSelect: 'none',
+  };
+  const numBtn: CSSProperties = { ...base, backgroundColor: '#eee' };  // digits + .
+  const opBtn: CSSProperties = { ...base, backgroundColor: '#ddd' };   // + - × ÷ ^ =
+  const funcBtn: CSSProperties = { ...base, backgroundColor: '#ccc' }; // ⌫ C
+  const confirmBtn: CSSProperties = { ...base, backgroundColor: '#ccc' };
+  const cancelBtn: CSSProperties = { ...base, backgroundColor: '#ccc', color: '#c00' };
+
+  return (
+    <wired-dialog open onClick={sp}>
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0, padding: '0.5em 0.75em 0.75em' }}>
+        {label && <div style={{ fontWeight: 'bold', fontSize: '0.85em', marginBottom: '0.3em' }}>{label}</div>}
+        {/* Expression display */}
+        <wired-card
+          tabIndex={0}
+          ref={dispRef as React.Ref<HTMLElement>}
+          style={{ width: '100%', fontSize: '1.3em', textAlign: 'right', padding: '0.5em 0.6em', marginBottom: '0.3em', fontFamily: 'monospace', minHeight: '2.8em', outline: 'none', cursor: 'default', userSelect: 'text', display: 'block', boxSizing: 'border-box' } as CSSProperties}
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e: React.KeyboardEvent) => {
+            if (/^[0-9]$/.test(e.key)) { append(e.key); return; }
+            if (e.key === '+') { append('+'); return; }
+            if (e.key === '-') { append('−'); return; }
+            if (e.key === '*') { append('×'); return; }
+            if (e.key === '/') { e.preventDefault(); append('÷'); return; }
+            if (e.key === '.') { append('.'); return; }
+            if (e.key === '(' || e.key === ')') { append(e.key); return; }
+            if (e.key === 'Backspace') { backspace(); return; }
+            if (e.key === 'Escape') { onCancel(); return; }
+            if (e.key === 'Enter') { evaluate(); return; }
+            if (e.key === 'Delete') { clear(); return; }
+          }}
+        >
+          {expr}
+        </wired-card>
+        {/* Row 1: ⌫ | C | ^ | ÷ */}
+        <div style={{ display: 'flex' }}>
+          <wired-card style={funcBtn} onClick={() => backspace()}>⌫</wired-card>
+          <wired-card style={funcBtn} onClick={() => clear()}>C</wired-card>
+          <wired-card style={opBtn} onClick={() => append('^')}>^</wired-card>
+          <wired-card style={opBtn} onClick={() => append('÷')}>÷</wired-card>
+        </div>
+        {/* Row 2: 7 8 9 × */}
+        <div style={{ display: 'flex' }}>
+          {['7','8','9'].map(k => <wired-card key={k} style={numBtn} onClick={() => append(k)}>{k}</wired-card>)}
+          <wired-card style={opBtn} onClick={() => append('×')}>×</wired-card>
+        </div>
+        {/* Row 3: 4 5 6 − */}
+        <div style={{ display: 'flex' }}>
+          {['4','5','6'].map(k => <wired-card key={k} style={numBtn} onClick={() => append(k)}>{k}</wired-card>)}
+          <wired-card style={opBtn} onClick={() => append('−')}>−</wired-card>
+        </div>
+        {/* Row 4: 1 2 3 + */}
+        <div style={{ display: 'flex' }}>
+          {['1','2','3'].map(k => <wired-card key={k} style={numBtn} onClick={() => append(k)}>{k}</wired-card>)}
+          <wired-card style={opBtn} onClick={() => append('+')}>+</wired-card>
+        </div>
+        {/* Row 5: . | 0 | = (wide) */}
+        <div style={{ display: 'flex', width: '100%' }}>
+          <wired-card style={numBtn} onClick={() => append('.')}>.</wired-card>
+          <wired-card style={numBtn} onClick={() => append('0')}>0</wired-card>
+          <wired-card style={{ ...opBtn, flex: 1 }} onClick={() => evaluate()}>=</wired-card>
+        </div>
+        {/* Row 6: Cancel (half) | Done (half) */}
+        <div style={{ display: 'flex', width: '100%', gap: 0 }}>
+          <wired-card style={{ ...cancelBtn, flex: 1, height: '3.5em' }} onClick={() => onCancel()}>
+            <Icon name='exit' />&nbsp;Cancel
+          </wired-card>
+          <wired-card style={{ ...confirmBtn, flex: 1, height: '3.5em' }} onClick={() => { if (valid && parsed !== null) onConfirm(parsed); }}>
+            <Icon name='done' />&nbsp;Set
+          </wired-card>
+        </div>
+      </div>
+    </wired-dialog>
+  );
+}

--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -25,20 +25,21 @@ const evalExpr = (expr: string): number | null => {
   }
 };
 
+const OPS = new Set(['+', '-', '*', '/', '×', '÷', '−', '^']);
+
 export function Calculator({ initialValue, onConfirm, onCancel, label }: CalculatorProps) {
   const [expr, setExpr] = useState(String(initialValue));
 
-  const ops = new Set(['+', '-', '*', '/', '×', '÷', '−', '^']);
   const append = (s: string) => setExpr(prev => {
     // Replace trailing operator with new one
-    if (ops.has(s) && prev.length > 0 && ops.has(prev.slice(-1))) {
+    if (OPS.has(s) && prev.length > 0 && OPS.has(prev.slice(-1))) {
       if (s === '−' && prev.slice(-1) !== '−') return prev + s; // allow negation only after non-minus op
       return prev.slice(0, -1) + s;  // replace operator (also handles −→− by replacing)
     }
     // Block double-minus when not following another operator
     if (s === '−' && prev.slice(-1) === '−') return prev;
     // Replace lone '0' with digit
-    if (!ops.has(s) && prev === '0') {
+    if (!OPS.has(s) && prev === '0') {
       return s;
     }
     return prev + s;
@@ -63,9 +64,7 @@ export function Calculator({ initialValue, onConfirm, onCancel, label }: Calcula
     display: 'flex', justifyContent: 'center', alignItems: 'center',
     cursor: 'pointer', borderRadius: '0.3em', userSelect: 'none',
   };
-  const numBtn: CSSProperties = { ...base, backgroundColor: '#e8e8e8' };
-  const opBtn: CSSProperties = { ...base, backgroundColor: '#e8e8e8' };
-  const funcBtn: CSSProperties = { ...base, backgroundColor: '#e8e8e8' };
+  const btn: CSSProperties = { ...base, backgroundColor: '#e8e8e8' };
   const confirmBtn: CSSProperties = { ...base, backgroundColor: '#ccc' };
   const cancelBtn: CSSProperties = { ...base, backgroundColor: '#ccc', color: '#c00' };
 
@@ -83,31 +82,31 @@ export function Calculator({ initialValue, onConfirm, onCancel, label }: Calcula
         </wired-card>
         {/* Row 1: ⌫ | C | ^ | ÷ */}
         <div style={{ display: 'flex' }}>
-          <wired-card style={funcBtn} onClick={() => backspace()}>⌫</wired-card>
-          <wired-card style={funcBtn} onClick={() => clear()}>C</wired-card>
-          <wired-card style={opBtn} onClick={() => append('^')}>^</wired-card>
-          <wired-card style={opBtn} onClick={() => append('÷')}>÷</wired-card>
+          <wired-card style={btn} onClick={() => backspace()}>⌫</wired-card>
+          <wired-card style={btn} onClick={() => clear()}>C</wired-card>
+          <wired-card style={btn} onClick={() => append('^')}>^</wired-card>
+          <wired-card style={btn} onClick={() => append('÷')}>÷</wired-card>
         </div>
         {/* Row 2: 7 8 9 × */}
         <div style={{ display: 'flex' }}>
-          {['7','8','9'].map(k => <wired-card key={k} style={numBtn} onClick={() => append(k)}>{k}</wired-card>)}
-          <wired-card style={opBtn} onClick={() => append('×')}>×</wired-card>
+          {['7','8','9'].map(k => <wired-card key={k} style={btn} onClick={() => append(k)}>{k}</wired-card>)}
+          <wired-card style={btn} onClick={() => append('×')}>×</wired-card>
         </div>
         {/* Row 3: 4 5 6 − */}
         <div style={{ display: 'flex' }}>
-          {['4','5','6'].map(k => <wired-card key={k} style={numBtn} onClick={() => append(k)}>{k}</wired-card>)}
-          <wired-card style={opBtn} onClick={() => append('−')}>−</wired-card>
+          {['4','5','6'].map(k => <wired-card key={k} style={btn} onClick={() => append(k)}>{k}</wired-card>)}
+          <wired-card style={btn} onClick={() => append('−')}>−</wired-card>
         </div>
         {/* Row 4: 1 2 3 + */}
         <div style={{ display: 'flex' }}>
-          {['1','2','3'].map(k => <wired-card key={k} style={numBtn} onClick={() => append(k)}>{k}</wired-card>)}
-          <wired-card style={opBtn} onClick={() => append('+')}>+</wired-card>
+          {['1','2','3'].map(k => <wired-card key={k} style={btn} onClick={() => append(k)}>{k}</wired-card>)}
+          <wired-card style={btn} onClick={() => append('+')}>+</wired-card>
         </div>
         {/* Row 5: . | 0 | = (wide) */}
         <div style={{ display: 'flex', width: '100%' }}>
-          <wired-card style={numBtn} onClick={() => append('.')}>.</wired-card>
-          <wired-card style={numBtn} onClick={() => append('0')}>0</wired-card>
-          <wired-card style={{ ...opBtn, flex: 1 }} onClick={() => evaluate()}>=</wired-card>
+          <wired-card style={btn} onClick={() => append('.')}>.</wired-card>
+          <wired-card style={btn} onClick={() => append('0')}>0</wired-card>
+          <wired-card style={{ ...btn, flex: 1 }} onClick={() => evaluate()}>=</wired-card>
         </div>
         {/* Row 6: Cancel (half) | Done (half) */}
         <div style={{ display: 'flex', width: '100%', gap: 0 }}>

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -260,7 +260,7 @@ export function Header(props: HeaderProps) {
       <div style={styles.header}>
         <div style={{ ...styles.item, ...styles.match }} onClick={ () => setShowShare(true) }><Icon name='copy' />&nbsp;{props.matchID !== 'default' ? `${props.matchID}` : "Blank White Cards"}</div>
         <div style={{ ...styles.item, ...styles.displayname }} onClick={() => { props.setShowPlayers(!props.showPlayers) }}>
-          {playerName}{playerName && <>&nbsp;{editingMyScore ? (
+          {playerName && (editingMyScore ? (
             <Calculator
               initialValue={myScore}
               label={playerName || undefined}
@@ -271,8 +271,8 @@ export function Header(props: HeaderProps) {
             <span
               style={{ fontVariantNumeric: 'tabular-nums', cursor: 'pointer', textDecoration: 'underline dotted' }}
               onClick={(e) => { e.stopPropagation(); setEditingMyScore(true); }}
-            >[{myScore}]</span>
-          )}</>}&nbsp;
+            >{playerName}: {myScore} pts</span>
+          ))}&nbsp;
           {props.matchID !== 'default' && <Icon name='multi' />}&nbsp;
           {props.matchData?.filter((player => player.isConnected)).length}
           {props.matchID !== 'default' && (props.matchData?.filter((player => player.isConnected)).length != 1) ? ((props.showPlayers) ? <Icon name='less' /> : <Icon name='more' />) : <>&nbsp;</> }

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -91,7 +91,6 @@ export function Players(props: BoardProps<GameState>) {
   } 
   const [openPlayers, setOpenPlayers] = useState<number[]>(initialOpenPlayers); // List of players with open table trays
   const [editingScore, setEditingScore] = useState<number | null>(null); // playerID being score-edited
-  const [editingScoreValue, setEditingScoreValue] = useState<number>(0);
   const styles: { [key: string]: Properties<string | number> } = {
     players: {
       maxWidth: '100vw',
@@ -151,6 +150,11 @@ export function Players(props: BoardProps<GameState>) {
       justifyContent: 'center',
       alignItems: 'center',
     },
+    score: {
+      fontSize: '1em',
+      lineHeight: 1,
+      fontWeight: 'bold',
+    },
   }
 
   const toggleOpenPlayers = (id: number) => {
@@ -175,10 +179,10 @@ export function Players(props: BoardProps<GameState>) {
               {(playerTable.length > 0) && ((!openPlayers.includes(player.id)) ? <Icon name='prev' /> : <Icon name='next' />)}
             </div>
             {(player.name).slice(0, 6)}{(player.name.length > 6) && '.'}
-            <div style={{ fontSize: '1em', lineHeight: 1, fontWeight: 'bold' }}>
+            <div style={styles.score}>
               <span
                 style={{ cursor: 'pointer', textDecoration: 'underline dotted' }}
-                onClick={(e) => { e.stopPropagation(); setEditingScore(player.id); setEditingScoreValue(score); }}
+                onClick={(e) => { e.stopPropagation(); setEditingScore(player.id); }}
               >{score}</span>
             </div>
           </wired-card>
@@ -203,7 +207,7 @@ export function Players(props: BoardProps<GameState>) {
     <div style={styles.players}>
       {editingScore !== null && (
         <Calculator
-          initialValue={editingScoreValue}
+          initialValue={editingScore !== null ? getPlayerScore(props.plugins, String(editingScore)) : 0}
           label={props.matchData?.find(p => p.id === editingScore)?.name}
           onConfirm={(val) => { props.moves.setScore(String(editingScore), val); setEditingScore(null); }}
           onCancel={() => setEditingScore(null)}

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -277,7 +277,7 @@ export function Header(props: HeaderProps) {
           {playerName}{playerName && <>&nbsp;{editingMyScore ? (
             <Calculator
               initialValue={myScore}
-              label="My Score"
+              label={playerName || undefined}
               onConfirm={(val) => { props.moves.setScore(props.playerID || '0', val); setEditingMyScore(false); }}
               onCancel={() => setEditingMyScore(false)}
             />

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -268,10 +268,10 @@ export function Header(props: HeaderProps) {
               onCancel={() => setEditingMyScore(false)}
             />
           ) : (
-            <span
+            <span>{playerName}: <span
               style={{ fontVariantNumeric: 'tabular-nums', cursor: 'pointer', textDecoration: 'underline dotted' }}
               onClick={(e) => { e.stopPropagation(); setEditingMyScore(true); }}
-            >{playerName}: {myScore} pts</span>
+            >{myScore} pts</span></span>
           ))}&nbsp;
           {props.matchID !== 'default' && <Icon name='multi' />}&nbsp;
           {props.matchData?.filter((player => player.isConnected)).length}

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -9,7 +9,29 @@ import { useCallback, useContext, useState } from 'react';
 import { useWindowDimensions } from '../lib/hooks.ts';
 import { FocusContext } from '../lib/contexts.ts';
 import { discordSdk } from '../lib/discord.ts';
-import { Likes } from './Focus.tsx';
+import { Calculator } from './Calculator.tsx';
+
+// Helper to read a player's score from the PluginPlayer data
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getPlayerScore = (plugins: any, playerID: string): number => {
+  return plugins?.player?.data?.players?.[playerID]?.score ?? 0;
+};
+
+// Format a score for display — raw up to 99,999, then SI prefixes (truncated), then Peta
+const formatScore = (n: number): string => {
+  const abs = Math.abs(n);
+  const sign = n < 0 ? '-' : '';
+  if (abs < 1e5) return String(n);
+  const fmt = (val: number, suffix: string) => {
+    const floored = Math.floor(val * 100) / 100;
+    return `${sign}${floored.toFixed(2).replace(/\.?0+$/, '')}${suffix}`;
+  };
+  if (abs < 1e6) return `${sign}${Math.floor(abs / 1e3)}k`;
+  if (abs < 1e9) return fmt(abs / 1e6, 'M');
+  if (abs < 1e12) return fmt(abs / 1e9, 'G');
+  if (abs < 1e15) return fmt(abs / 1e12, 'T');
+  return `${sign}${abs.toExponential(2).replace('e+', ' e').replace('e-', ' e-').replace('e', ' e')}`;
+};
 
 export function Pile(props: BoardProps<GameState>) {
   const { focus, setFocus } = useContext(FocusContext);
@@ -82,6 +104,8 @@ export function Players(props: BoardProps<GameState>) {
     }
   } 
   const [openPlayers, setOpenPlayers] = useState<number[]>(initialOpenPlayers); // List of players with open table trays
+  const [editingScore, setEditingScore] = useState<number | null>(null); // playerID being score-edited
+  const [editingScoreValue, setEditingScoreValue] = useState<number>(0);
   const styles: { [key: string]: Properties<string | number> } = {
     players: {
       maxWidth: '100vw',
@@ -115,7 +139,7 @@ export function Players(props: BoardProps<GameState>) {
       borderRadius: '0.5em',
       textAlign: 'center',
       display: 'flex',
-      flexDirection: 'row',
+      flexDirection: 'column',
       justifyContent: 'center',
       alignItems: 'center',
     },
@@ -156,15 +180,21 @@ export function Players(props: BoardProps<GameState>) {
   const playerAvatars = props.matchData ? props.matchData.map((player, i) => {
     if (player.isConnected && player.name && player.id != Number(props.playerID)) { 
       const playerTable = getCardsByLocation(getCardsByOwner(props.G.cards, String(player.id)), 'table').sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0)); // Oldest to Newest
+      const score = getPlayerScore(props.plugins, String(player.id));
       
       return (
         <div key={`player-avatar-${i}`} style={styles.avatarBox}>
           <wired-card style={styles.avatar} onClick={() => { if (playerTable.length > 0) { toggleOpenPlayers(player.id) }}}>
             <div style={styles.stats}>
               {(playerTable.length > 0) && ((!openPlayers.includes(player.id)) ? <Icon name='prev' /> : <Icon name='next' />)}
-              <Icon name='single' />
             </div>
             {(player.name).slice(0, 6)}{(player.name.length > 6) && '.'}
+            <div style={{ fontSize: '1em', lineHeight: 1, fontWeight: 'bold' }}>
+              <span
+                style={{ cursor: 'pointer', textDecoration: 'underline dotted' }}
+                onClick={(e) => { e.stopPropagation(); setEditingScore(player.id); setEditingScoreValue(score); }}
+              >{formatScore(score)}</span>
+            </div>
           </wired-card>
           {
             openPlayers.includes(player.id) &&
@@ -185,6 +215,14 @@ export function Players(props: BoardProps<GameState>) {
 
   return (
     <div style={styles.players}>
+      {editingScore !== null && (
+        <Calculator
+          initialValue={editingScoreValue}
+          label={props.matchData?.find(p => p.id === editingScore)?.name}
+          onConfirm={(val) => { props.moves.setScore(String(editingScore), val); setEditingScore(null); }}
+          onCancel={() => setEditingScore(null)}
+        />
+      )}
       {playerAvatars}
     </div>
   )
@@ -197,9 +235,11 @@ interface HeaderProps extends BoardProps<GameState> {
 
 export function Header(props: HeaderProps) {
   const [showShare, setShowShare] = useState(false);
+  const [editingMyScore, setEditingMyScore] = useState(false);
   const dimensions = useWindowDimensions();
 
   const playerName = props.isMultiplayer && props.matchData?.find((player) => player.id == Number(props.playerID))?.name?.toUpperCase() || ""
+  const myScore = getPlayerScore(props.plugins, props.playerID || '0');
 
   const styles: { [key: string]: Properties<string | number> } = {
     header: {
@@ -234,7 +274,19 @@ export function Header(props: HeaderProps) {
       <div style={styles.header}>
         <div style={{ ...styles.item, ...styles.match }} onClick={ () => setShowShare(true) }><Icon name='copy' />&nbsp;{props.matchID !== 'default' ? `${props.matchID}` : "Blank White Cards"}</div>
         <div style={{ ...styles.item, ...styles.displayname }} onClick={() => { props.setShowPlayers(!props.showPlayers) }}>
-          {playerName}&nbsp;
+          {playerName}{playerName && <>&nbsp;{editingMyScore ? (
+            <Calculator
+              initialValue={myScore}
+              label="My Score"
+              onConfirm={(val) => { props.moves.setScore(props.playerID || '0', val); setEditingMyScore(false); }}
+              onCancel={() => setEditingMyScore(false)}
+            />
+          ) : (
+            <span
+              style={{ fontVariantNumeric: 'tabular-nums', cursor: 'pointer', textDecoration: 'underline dotted' }}
+              onClick={(e) => { e.stopPropagation(); setEditingMyScore(true); }}
+            >[{formatScore(myScore)}]</span>
+          )}</>}&nbsp;
           {props.matchID !== 'default' && <Icon name='multi' />}&nbsp;
           {props.matchData?.filter((player => player.isConnected)).length}
           {props.matchID !== 'default' && (props.matchData?.filter((player => player.isConnected)).length != 1) ? ((props.showPlayers) ? <Icon name='less' /> : <Icon name='more' />) : <>&nbsp;</> }

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -272,10 +272,10 @@ export function Header(props: HeaderProps) {
               onCancel={() => setEditingMyScore(false)}
             />
           ) : (
-            <span>{playerName} <span
+            <>{playerName} <span
               style={{ fontVariantNumeric: 'tabular-nums', cursor: 'pointer', textDecoration: 'underline dotted' }}
               onClick={(e) => { e.stopPropagation(); setEditingMyScore(true); }}
-            >{formatScore(myScore)} pts</span></span>
+            >{formatScore(myScore)} pts</span></>
           ))}&nbsp;
           {props.matchID !== 'default' && <Icon name='multi' />}&nbsp;
           {props.matchData?.filter((player => player.isConnected)).length}

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -9,6 +9,7 @@ import { useCallback, useContext, useState } from 'react';
 import { useWindowDimensions } from '../lib/hooks.ts';
 import { FocusContext } from '../lib/contexts.ts';
 import { discordSdk } from '../lib/discord.ts';
+import { Likes } from './Focus.tsx';
 import { Calculator } from './Calculator.tsx';
 
 // Helper to read a player's score from the PluginPlayer data

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -10,7 +10,7 @@ import { useWindowDimensions } from '../lib/hooks.ts';
 import { FocusContext } from '../lib/contexts.ts';
 import { discordSdk } from '../lib/discord.ts';
 import { Likes } from './Focus.tsx';
-import { Calculator } from './Calculator.tsx';
+import { Calculator, formatScore } from './Calculator.tsx';
 
 // Helper to read a player's score from the PluginPlayer data
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -183,7 +183,7 @@ export function Players(props: BoardProps<GameState>) {
               <span
                 style={{ cursor: 'pointer', textDecoration: 'underline dotted' }}
                 onClick={(e) => { e.stopPropagation(); setEditingScore(player.id); }}
-              >{score}</span>
+              >{formatScore(score)}</span>
             </div>
           </wired-card>
           {
@@ -275,7 +275,7 @@ export function Header(props: HeaderProps) {
             <span>{playerName} <span
               style={{ fontVariantNumeric: 'tabular-nums', cursor: 'pointer', textDecoration: 'underline dotted' }}
               onClick={(e) => { e.stopPropagation(); setEditingMyScore(true); }}
-            >{myScore} pts</span></span>
+            >{formatScore(myScore)} pts</span></span>
           ))}&nbsp;
           {props.matchID !== 'default' && <Icon name='multi' />}&nbsp;
           {props.matchData?.filter((player => player.isConnected)).length}

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -272,7 +272,7 @@ export function Header(props: HeaderProps) {
               onCancel={() => setEditingMyScore(false)}
             />
           ) : (
-            <>{playerName} <span
+            <>{playerName}&nbsp;<span
               style={{ fontVariantNumeric: 'tabular-nums', cursor: 'pointer', textDecoration: 'underline dotted' }}
               onClick={(e) => { e.stopPropagation(); setEditingMyScore(true); }}
             >{formatScore(myScore)} pts</span></>

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -30,7 +30,7 @@ export const formatScore = (n: number): string => {
   if (abs < 1e9) return fmt(abs / 1e6, 'M');
   if (abs < 1e12) return fmt(abs / 1e9, 'G');
   if (abs < 1e15) return fmt(abs / 1e12, 'T');
-  return `${sign}${abs.toExponential(2).replace('e+', ' e').replace('e-', ' e-').replace('e', ' e')}`;
+  return `${sign}${abs.toExponential(3).replace('e+', ' e').replace('e-', ' e-').replace('e', ' e')}`;
 };
 
 export function Pile(props: BoardProps<GameState>) {

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -17,21 +17,7 @@ const getPlayerScore = (plugins: any, playerID: string): number => {
   return plugins?.player?.data?.players?.[playerID]?.score ?? 0;
 };
 
-// Format a score for display — raw up to 99,999, then SI prefixes (truncated), then Peta
-export const formatScore = (n: number): string => {
-  const abs = Math.abs(n);
-  const sign = n < 0 ? '-' : '';
-  if (abs < 1e5) return String(n);
-  const fmt = (val: number, suffix: string) => {
-    const floored = Math.floor(val * 100) / 100;
-    return `${sign}${floored.toFixed(2).replace(/\.?0+$/, '')}${suffix}`;
-  };
-  if (abs < 1e6) return `${sign}${Math.floor(abs / 1e3)}k`;
-  if (abs < 1e9) return fmt(abs / 1e6, 'M');
-  if (abs < 1e12) return fmt(abs / 1e9, 'G');
-  if (abs < 1e15) return fmt(abs / 1e12, 'T');
-  return `${sign}${abs.toExponential(3).replace('e+', ' e').replace('e-', ' e-').replace('e', ' e')}`;
-};
+import { formatScore } from './Calculator.tsx';
 
 export function Pile(props: BoardProps<GameState>) {
   const { focus, setFocus } = useContext(FocusContext);

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -268,7 +268,7 @@ export function Header(props: HeaderProps) {
               onCancel={() => setEditingMyScore(false)}
             />
           ) : (
-            <span>{playerName}: <span
+            <span>{playerName} <span
               style={{ fontVariantNumeric: 'tabular-nums', cursor: 'pointer', textDecoration: 'underline dotted' }}
               onClick={(e) => { e.stopPropagation(); setEditingMyScore(true); }}
             >{myScore} pts</span></span>

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -17,7 +17,6 @@ const getPlayerScore = (plugins: any, playerID: string): number => {
   return plugins?.player?.data?.players?.[playerID]?.score ?? 0;
 };
 
-import { formatScore } from './Calculator.tsx';
 
 export function Pile(props: BoardProps<GameState>) {
   const { focus, setFocus } = useContext(FocusContext);
@@ -179,7 +178,7 @@ export function Players(props: BoardProps<GameState>) {
               <span
                 style={{ cursor: 'pointer', textDecoration: 'underline dotted' }}
                 onClick={(e) => { e.stopPropagation(); setEditingScore(player.id); setEditingScoreValue(score); }}
-              >{formatScore(score)}</span>
+              >{score}</span>
             </div>
           </wired-card>
           {
@@ -271,7 +270,7 @@ export function Header(props: HeaderProps) {
             <span
               style={{ fontVariantNumeric: 'tabular-nums', cursor: 'pointer', textDecoration: 'underline dotted' }}
               onClick={(e) => { e.stopPropagation(); setEditingMyScore(true); }}
-            >[{formatScore(myScore)}]</span>
+            >[{myScore}]</span>
           )}</>}&nbsp;
           {props.matchID !== 'default' && <Icon name='multi' />}&nbsp;
           {props.matchData?.filter((player => player.isConnected)).length}

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -18,7 +18,7 @@ const getPlayerScore = (plugins: any, playerID: string): number => {
 };
 
 // Format a score for display — raw up to 99,999, then SI prefixes (truncated), then Peta
-const formatScore = (n: number): string => {
+export const formatScore = (n: number): string => {
   const abs = Math.abs(n);
   const sign = n < 0 ? '-' : '';
   if (abs < 1e5) return String(n);

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -207,7 +207,7 @@ export function Players(props: BoardProps<GameState>) {
     <div style={styles.players}>
       {editingScore !== null && (
         <Calculator
-          initialValue={editingScore !== null ? getPlayerScore(props.plugins, String(editingScore)) : 0}
+          initialValue={getPlayerScore(props.plugins, String(editingScore))}
           label={props.matchData?.find(p => p.id === editingScore)?.name}
           onConfirm={(val) => { props.moves.setScore(String(editingScore), val); setEditingScore(null); }}
           onCancel={() => setEditingScore(null)}

--- a/core/src/Game.ts
+++ b/core/src/Game.ts
@@ -1,5 +1,6 @@
 import type { Game, Move } from "boardgame.io";
 import { INVALID_MOVE, Stage } from 'boardgame.io/core';
+import { PluginPlayer } from 'boardgame.io/plugins';
 import { Card, getCardById, getCardsByLocation } from './Cards';
 import { presetDecks } from "./lib/constants";
 
@@ -122,6 +123,15 @@ const shuffleCards: Move<GameState> = ({ G, playerID }) => {
   });
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const setScore: Move<GameState> = ({ player }: any, targetPlayerID: string, value: number) => {
+  if (player?.state && targetPlayerID in player.state) {
+    player.state[targetPlayerID] = { score: value };
+  } else {
+    return INVALID_MOVE;
+  }
+}
+
 // Game
 export const BlankWhiteCards: Game<GameState> = {
   name: 'blank-white-cards',
@@ -177,7 +187,16 @@ export const BlankWhiteCards: Game<GameState> = {
       client: false,
       ignoreStaleStateID: true,
     },
+    setScore: {
+      move: setScore,
+      client: false,
+      ignoreStaleStateID: true,
+    },
   },
+
+  plugins: [
+    PluginPlayer({ setup: () => ({ score: 0 as number }) }),
+  ],
 
   turn: {
     activePlayers: { all: Stage.NULL },


### PR DESCRIPTION
## Game scoring system (BWC-9)

Implements per-player score tracking. Scores are manually assigned — any connected player can click another player's score to open a calculator and set it. Your own score is editable from the header.

## What changed

### core/src/Game.ts
- Added `PluginPlayer` with `{ score: 0 }` per player
- Added `setScore(targetPlayerID, value)` move with `client: false` and `ignoreStaleStateID: true`

### app/src/Components/Calculator.tsx (new)
- Full expression evaluator using `new Function` (safe subset)
- iPhone-style 5-row keypad: ⌫/C/^/÷, 7-9/×, 4-6/−, 1-3/+, ./0/=
- Cancel and Done row below
- Operator rules: replaces trailing operator, allows negation (×−), blocks double-minus
- `formatScore` exported: SI prefixes (k/M/G/T), 4 sig figs, `<0.01`/`>-0.01` floor, scientific notation beyond T

### app/src/Components/CommonSpace.tsx
- Player avatar tiles: score shown below name, click to open Calculator
- Header: `KIRO 0 pts` format, score is clickable (dotted underline)
- Both use `formatScore` for display

## Key bugs found
- `client: false` required — plugin API unavailable on client, move reverted without it
- `getPlayerScore` must read from `props.plugins`, not `ctx.plugins`
- Leading-zero stripping regex broke `0.01` → fixed with negative lookbehind

## Files
- `core/src/Game.ts` — +19 lines
- `app/src/Components/Calculator.tsx` — new, 142 lines
- `app/src/Components/CommonSpace.tsx` — +48 lines

Closes BWC-9