### PR TITLE
feat: MCP scoring tools and avatar table indicator (BWC-10)

### DIFF
--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -127,7 +127,6 @@ export function Players(props: BoardProps<GameState>) {
       flexDirection: 'column',
       justifyContent: 'center',
       alignItems: 'center',
-      position: 'relative',
     },
     tableBox: {
       maxHeight: '60vh',

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -112,7 +112,7 @@ export function Players(props: BoardProps<GameState>) {
       display: 'flex',
       flexDirection: 'row-reverse',
       justifyContent: 'flex-start',
-      alignItems: 'flex-start',
+      alignItems: 'center',
     },
     avatar: {
       height: '3em',
@@ -127,6 +127,7 @@ export function Players(props: BoardProps<GameState>) {
       flexDirection: 'column',
       justifyContent: 'center',
       alignItems: 'center',
+      position: 'relative',
     },
     tableBox: {
       maxHeight: '60vh',
@@ -136,7 +137,7 @@ export function Players(props: BoardProps<GameState>) {
       borderRadius: '0.5em',
       zIndex: '5',
       position: (dimensions.upright) ? 'fixed' : 'relative',
-      right: (dimensions.upright) ? '4.5em' : undefined,
+      right: (dimensions.upright) ? '5em' : undefined,
       backgroundColor: (dimensions.upright) ? 'rgba(0, 0, 0, 0.5)' : 'rgba(255, 255, 255, 0.5)',
       display: 'flex',
       flexDirection: 'row',
@@ -145,10 +146,7 @@ export function Players(props: BoardProps<GameState>) {
       flexWrap: 'wrap',
     },
     stats: {
-      display: 'flex',
-      flexDirection: 'row',
-      justifyContent: 'center',
-      alignItems: 'center',
+      fontSize: '0.8em',
     },
     score: {
       fontSize: '1em',
@@ -175,9 +173,6 @@ export function Players(props: BoardProps<GameState>) {
       return (
         <div key={`player-avatar-${i}`} style={styles.avatarBox}>
           <wired-card style={styles.avatar} onClick={() => { if (playerTable.length > 0) { toggleOpenPlayers(player.id) }}}>
-            <div style={styles.stats}>
-              {(playerTable.length > 0) && ((!openPlayers.includes(player.id)) ? <Icon name='prev' /> : <Icon name='next' />)}
-            </div>
             {(player.name).slice(0, 6)}{(player.name.length > 6) && '.'}
             <div style={styles.score}>
               <span
@@ -186,6 +181,7 @@ export function Players(props: BoardProps<GameState>) {
               >{formatScore(score)}</span>
             </div>
           </wired-card>
+          {(playerTable.length > 0) && <span style={styles.stats}>{(!openPlayers.includes(player.id)) ? '<' : '>'}</span>}
           {
             openPlayers.includes(player.id) &&
             <div style={styles.tableBox}>

--- a/docs/local.md
+++ b/docs/local.md
@@ -15,7 +15,7 @@ npm run pull:global
 
 ### 2. Start the local Lobby & Game server
 ```
-npm run serve:local
+npm run local
 ```
 This will run a `boardgame.io` server at http://localhost:3000
 
@@ -105,9 +105,18 @@ By default, the MCP server connects to the public game servers (ap/eu/na.blankwh
 
 **HTTP mode** (for remote clients):
 ```
-GAME_SERVER_URL=<YOUR_GAME_SERVER> npm run serve:mcp
+npm run serve:mcp
 ```
-This starts a Streamable HTTP server on port 8000.
+This starts a Streamable HTTP server on port 8000 (overridable via `MCP_HTTP_PORT`), connecting to the public game servers.
+
+To run against your local game server instead:
+```
+npm run local:mcp
+```
+This defaults `GAME_SERVER_URL` to `http://localhost:3000`. You can override it:
+```
+GAME_SERVER_URL=http://192.168.1.10:3000 npm run local:mcp
+```
 
 Add to your MCP client config:
 ```json

--- a/mcp/Containerfile
+++ b/mcp/Containerfile
@@ -9,6 +9,7 @@ RUN npx esbuild index.ts --bundle --platform=node --format=cjs --outfile=dist/in
 FROM node:26-alpine
 WORKDIR /app
 ENV NODE_ENV=production MCP_HTTP_PORT=8000
+RUN apk add --no-cache ffmpeg
 COPY --from=build /app/dist/index.js .
 EXPOSE 8000
 CMD ["node", "index.js"]

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -49,7 +49,6 @@ When `GAME_SERVER_URL` is not set:
 ## Tools
 
 ### Match management
-- `list_matches` — List active matches
 - `create_match` — Create a new match and join as player 0
 - `join_match` — Join an existing match
 - `leave_match` — Leave a match

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -5,14 +5,39 @@ An MCP (Model Context Protocol) server that lets AI agents play Blank White Card
 ## Requirements
 
 - Node.js 20+
-- A running Blank White Cards game server (boardgame.io)
 - ffmpeg/ffprobe (optional, only needed for card images)
 
-## Running
+## MCP Client Config
 
-```bash
-npx tsx mcp/index.ts
+### Stdio (recommended)
+
+```json
+{
+  "mcpServers": {
+    "blank-white-cards": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["@mcteamster/white-mcp"]
+    }
+  }
+}
 ```
+
+### HTTP (remote clients)
+
+Point your MCP client at a running HTTP instance:
+
+```json
+{
+  "mcpServers": {
+    "blank-white-cards": {
+      "url": "https://ap.blankwhite.cards/mcp"
+    }
+  }
+}
+```
+
+Public HTTP endpoints: `ap.blankwhite.cards/mcp`, `eu.blankwhite.cards/mcp`, `na.blankwhite.cards/mcp`
 
 ## Configuration
 
@@ -20,47 +45,43 @@ Environment variables:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `GAME_SERVER_URL` | *(auto-detect)* | Override server URL for all connections. If unset, the server is resolved from the room code or timezone. |
+| `GAME_SERVER_URL` | *(auto-detect)* | Override server URL for all connections. If unset, resolved from room code or timezone. |
+| `MCP_HTTP_PORT` | *(stdio)* | Set to run as an HTTP server (e.g. `8000`) |
 | `MCP_MIN_REACT_SECONDS` | `5` | Seconds to wait before returning watch events (pacing) |
 | `MCP_MAX_WATCH_SECONDS` | `30` | Seconds before watch times out with no event |
 
 ### Server resolution
 
 When `GAME_SERVER_URL` is not set:
-- **Joining a match** — the server is derived from the room code's last character (AP/EU/NA regions)
-- **Creating a match** — auto-detects the closest region from your timezone, or accepts a `region` parameter
-- **Unrecognised room codes** — falls back to `http://localhost:3000` (local development)
+- **Joining a match** — server derived from the room code's last character (AP/EU/NA regions)
+- **Creating a match** — auto-detects closest region from timezone, or accepts a `region` parameter
+- **Unrecognised room codes** — falls back to `http://localhost:3000`
 
-## MCP Client Config
+## Running locally
 
-```json
-{
-  "blank-white-cards": {
-    "type": "stdio",
-    "command": "npx",
-    "args": ["--prefix", "/path/to/white", "tsx", "/path/to/white/mcp/index.ts"],
-    "env": {
-      "GAME_SERVER_URL": "http://localhost:3000"
-    }
-  }
-}
+```bash
+# Game server (boardgame.io)
+npm run local
+
+# MCP server pointing at local game server
+npm run local:mcp
 ```
 
 ## Tools
 
 ### Match management
 - `create_match` — Create a new match and join as player 0
-- `join_match` — Join an existing match
+- `join_match` — Join an existing match (omit `playerID` to auto-assign a seat)
 - `leave_match` — Leave a match
 
 ### Game state
-- `get_state` — Get current game state (hand, pile, deck size, etc.)
+- `get_state` — Get current game state (hand, pile, deck size, scores, etc.)
 - `get_card` — Get a single card by ID
 - `search_cards` — Full-text search over card titles and descriptions
 - `export_deck` — Export all cards in a match as JSON
 
 ### Actions
-- `pickup_card` — Draw from the deck into your hand
+- `pickup_card` — Pick up a card from the deck. If the deck is empty, reshuffles the pile and discard first.
 - `move_card` — Move a card to a different location
 - `claim_card` — Claim a card from the pile into your hand
 - `submit_card` — Write a new card (optionally with an image)
@@ -68,19 +89,25 @@ When `GAME_SERVER_URL` is not set:
 - `shuffle_cards` — Reset and shuffle all cards (host only)
 - `load_cards` — Bulk load cards into a match (host only)
 
+### Scoring
+- `get_scores` — Get current scores for all players
+- `get_leaderboard` — Get players ranked by score
+- `set_score` — Set a player's score
+- `get_play_hint` — Get a suggested next action based on game state and score position
+
 ### Observation
-- `watch` — Block until a game event occurs, returns structured diff of what changed
+- `watch` — Block until a game event occurs, returns structured diff of what changed plus a session watch counter
 
 ## Card Images
 
-Cards can optionally have images. The agent saves a square PNG to disk and passes the file path as `image_path` in `submit_card`. The server:
+Cards can optionally have images. Pass a square PNG file path as `image_path` in `submit_card`. The server:
 
 1. Validates the image is square (via ffprobe)
 2. Resizes to 500x500
-3. Converts to black and white (threshold at 128)
+3. Converts to 1-bit black and white
 4. Attaches as a PNG data URI
 
-Requires ffmpeg and ffprobe on the system PATH.
+Use a white background with bold black line art for best results. Requires ffmpeg and ffprobe on PATH.
 
 ## Prompts
 
@@ -88,14 +115,11 @@ The server provides role prompts that shape how an agent uses the tools:
 
 | Prompt | Description | Parameters |
 |--------|-------------|------------|
-| `autonomous_player` | Play the game in a loop | `tone`, `themes`, `aggression` |
+| `autoplay` | Autonomously play the game in a loop | `tone`, `themes`, `aggression` |
 | `referee` | Moderate and enforce rules | `rules` |
-| `spectator` | Watch and comment only | — |
-| `deck_builder` | Create and curate card decks | `theme`, `card_count` |
+| `spectate` | Watch and comment only | — |
 
 ## Pacing
 
-The server enforces pacing to prevent agents from acting too fast:
-
 - When `watch` detects an event, it waits `MCP_MIN_REACT_SECONDS` before returning — giving human players time to read new cards
-- When `watch` times out, the response nudges the agent to take action and re-watch
+- When `watch` times out, the response nudges the agent to act and re-watch

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -337,7 +337,7 @@ function requireSession(matchID: string, playerID: string): Session {
 
 export function createMcpServer() {
 const mcp = new McpServer(
-  { name: 'blank-white-cards', version: '2.3.2' },
+  { name: 'blank-white-cards', version: '2.3.4' },
   { instructions: INSTRUCTIONS },
 );
 

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -256,20 +256,16 @@ This server provides tools for interacting with Blank White Cards — a creative
 
 ## Card locations
 
-- **deck** — cards not yet picked up. 'pickup_card' takes one into your hand.
+- **deck** — cards not yet picked up. 'pickup_card' takes one into your hand. If the deck is empty, 'pickup_card' reshuffles the pile and discard back into the deck automatically.
 - **hand** — a player's private cards. 'move_card' plays them elsewhere.
 - **pile** — the shared active area, visible to everyone.
-- **table** — cards placed in front of a specific player (persistent effects).
-- **discard** — removed from play.
-- **box** — cards set aside outside the game.
+- **table** — cards placed in front of a specific player and stay there as a persistent effect until explicitly moved.
+- **discard** — removed from play but can be reshuffled back into the deck.
+- **box** — cards permanently outside the game, set at load time. Cards cannot be moved to or from the box during play.
 
-## Observing changes
+## Writing vs playing cards
 
-Use 'watch' to block until a relevant event occurs (card submitted, claimed, moved, liked, or shuffled). This is more efficient than polling 'get_state'. Only one 'watch' can be active per session.
-
-## Writing cards
-
-'submit_card' creates a new card in a player's hand. Use 'move_card' to play it to the pile or elsewhere.
+'submit_card' creates a **new** card and puts it in your hand. 'move_card' moves an **existing** card from your hand to the pile (or elsewhere). To play a card you wrote: call 'submit_card' first, then 'move_card' with the returned card ID.
 
 ## Card images
 
@@ -288,7 +284,7 @@ Players have scores tracked per-match. Scores are set manually — they are not 
 
 ## Available prompts
 
-This server provides role prompts (player, referee, spectator) that describe how to use these tools for specific purposes. List prompts to see available roles.
+This server provides role prompts (autoplay, referee, spectate) that describe how to use these tools for specific purposes. List prompts to see available roles.
 `.trim();
 
 
@@ -402,19 +398,20 @@ mcp.registerTool(
     description: 'Join an existing match as a specific player',
     inputSchema: {
       matchID: z.string().describe('Room code'),
-      playerID: z.string().describe('Seat number to join, e.g. "0", "1", "2"'),
+      playerID: z.string().optional().describe('Seat number to join, e.g. "0", "1", "2" (default: first open seat)'),
       player_name: z.string().optional().describe('Your display name'),
     },
   },
   async ({ matchID, playerID, player_name }) => {
     const server = getServerForMatch(matchID);
     const lobby = new LobbyClient({ server });
-    const { playerCredentials } = await lobby.joinMatch(GAME_NAME, matchID, {
+    const { playerID: assignedID, playerCredentials } = await lobby.joinMatch(GAME_NAME, matchID, {
       playerID,
-      playerName: player_name ?? `Player ${playerID}`,
+      playerName: player_name ?? `Player ${playerID ?? '?'}`,
     });
-    await connectSession(matchID, playerID, playerCredentials, server);
-    return text({ matchID, playerID, server, message: `Joined ${matchID} as player ${playerID}` });
+    const id = assignedID ?? playerID!;
+    await connectSession(matchID, id, playerCredentials, server);
+    return text({ matchID, playerID: id, server, message: `Joined ${matchID} as player ${id}` });
   }
 );
 
@@ -504,7 +501,7 @@ mcp.registerTool(
 mcp.registerTool(
   'pickup_card',
   {
-    description: 'Pick up a card from the deck into your hand',
+    description: 'Pick up a card from the deck into your hand. If the deck is empty, calling this will automatically reshuffle the pile and discard back into the deck first — so call it even when the deck is empty.',
     inputSchema: {
       matchID: z.string().describe('Room code'),
       playerID: z.string().describe('Your player ID'),
@@ -858,8 +855,8 @@ mcp.registerTool(
 // ── Prompts ───────────────────────────────────────────────────────────────────
 
 mcp.prompt(
-  'player',
-  'Play the game — pick up cards, write creative cards, react to other players',
+  'autoplay',
+  'Autonomously play Blank White Cards — pick up cards, write and play creative cards, react to other players, loop forever',
   {
     tone: z.enum(['whimsical', 'serious', 'absurdist', 'competitive', 'collaborative']).optional().describe('Writing tone for cards you create'),
     themes: z.string().optional().describe('Comma-separated topic interests, e.g. "sci-fi, puns, local history"'),
@@ -907,6 +904,8 @@ You may choose to draw or generate an image to go with a card. Save it as a squa
 
 ${a === 'aggressive' ? 'Submit cards frequently and respond to everything on the pile. Be the one driving the game. Check get_scores regularly and let your position drive decisions.' : a === 'passive' ? 'Observe more than you act. Like cards you enjoy. Only submit when you have something worth playing.' : 'Submit when the pile is quiet, react when things get interesting, like cards you genuinely enjoy.'}
 
+Keep 1–3 cards in hand at any time. Don't hoard and don't play everything immediately.
+
 Do not narrate. Do not explain. Just play.`,
         },
       }],
@@ -930,6 +929,12 @@ mcp.prompt(
           type: 'text',
           text: `You are a referee/arbiter for Blank White Cards. You do NOT play cards yourself — you manage the game.
 
+## CRITICAL: Never stop refereeing
+
+You MUST keep watching and moderating indefinitely. Never summarise what you've done. Never ask the user what to do next. Never say "let me know if you want me to continue." You are not having a conversation — you are running a game in an infinite loop until the process is killed.
+
+After EVERY event or timeout → handle it → call 'watch' again immediately. There is no finish line.
+
 ## Responsibilities
 
 - Watch for rule violations and announce them (use 'submit_card' to post a ruling card if needed).
@@ -937,14 +942,14 @@ mcp.prompt(
 - Move cards that are misplaced ('move_card').
 - Discard cards that violate house rules.
 - Keep the game flowing — if no one has acted in a while, draw attention by posting a prompt card.
-- Award points for good card play using 'set_score'. Use your judgment — creative cards, well-executed rules, and crowd-pleasing moments are worth rewarding.
+- Award points for good card play using 'set_score'. Suggested scale: 1 point for a solid play, 2 for something clever or well-timed, 3 for a genuinely outstanding card. Identify yourself as "Referee" in any cards you submit using the 'author' field.
 - Post a leaderboard update periodically by calling 'get_leaderboard' and submitting a card with the current standings.
 
 ## How to monitor
 
 Call 'watch' with all flags ('pile: true', 'hand: true', 'table: true') to see everything that happens. When an event fires, handle it and re-issue 'watch' immediately.
 
-Keep a count of consecutive timeouts. If 'watch' times out 10 times in a row with no events, the game has likely ended or gone quiet — call 'get_leaderboard', post a final standings card, and stop watching.
+Keep a count of consecutive timeouts. If 'watch' times out 10 times in a row with no events, the game has truly gone stale — call 'get_leaderboard', post a final standings card, and stop.
 
 Use 'search_cards' and 'get_card' to inspect specific cards when reviewing content.${ruleBlock}`,
         },
@@ -954,7 +959,7 @@ Use 'search_cards' and 'get_card' to inspect specific cards when reviewing conte
 );
 
 mcp.prompt(
-  'spectator',
+  'spectate',
   'Watch the game and provide commentary without taking game actions',
   {},
   () => ({
@@ -964,6 +969,12 @@ mcp.prompt(
         type: 'text',
         text: `You are a spectator of Blank White Cards. You observe and comment but do NOT play cards, claim cards, or pick up from the deck.
 
+## CRITICAL: Never stop watching
+
+You MUST keep watching and commentating indefinitely. Never ask the user what to do next. Never say "let me know if you want me to continue." You are not having a conversation — you are providing live commentary in an infinite loop until the process is killed or the game truly goes stale.
+
+After EVERY 'watch' response (fired or timed out) → provide commentary → call 'watch' again immediately. Keep a count of consecutive timeouts. If 'watch' times out 10 times in a row with no events, the game has truly gone stale — give a final summary and stop.
+
 ## What you can do
 
 - Use 'get_state' to see the current game.
@@ -971,9 +982,7 @@ mcp.prompt(
 - Use 'get_card' and 'search_cards' to read cards in detail.
 - Use 'like_card' to show appreciation for cards you enjoy.
 - Use 'get_scores' and 'get_leaderboard' to track standings and include them in your commentary.
-- Provide commentary, narration, or play-by-play to the user.
-
-Only stop watching if the user explicitly tells you to.
+- Provide commentary, narration, or play-by-play to the user. One short comment per routine event; longer analysis for notable or surprising plays.
 
 ## What you should NOT do
 

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -1004,7 +1004,6 @@ import { createServer } from 'http';
 import { randomUUID } from 'crypto';
 
 // Run as entrypoint (stdio or HTTP), skip when imported as library
-// Run as entrypoint (stdio or HTTP), skip when imported as library
 const isCLI = typeof require !== 'undefined'
   ? require.main === module  // CJS bundle
   : process.argv[1] && import.meta.url === `file://${process.argv[1]}`;

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -71,9 +71,16 @@ function stripImage(card: Card) {
   return { id: card.id, content, location: card.location, owner: card.owner, likes: card.likes };
 }
 
+function getScores(state: Record<string, unknown>, playOrder: string[]): Record<string, number> {
+  const players = (state as any)?.plugins?.player?.data?.players as Record<string, { score: number }> | undefined;
+  return Object.fromEntries(playOrder.map(id => [id, players?.[id]?.score ?? 0]));
+}
+
 function formatState(state: { G: { cards: Card[] }; ctx: Record<string, unknown> }, playerID: string) {
   const { G, ctx } = state;
   const cards = G.cards;
+  const playOrder = ctx.playOrder as string[];
+  const scores = getScores(state as Record<string, unknown>, playOrder);
   return {
     my_hand: cards.filter(c => c.location === 'hand' && c.owner === playerID).map(stripImage),
     my_table: cards.filter(c => c.location === 'table' && c.owner === playerID).map(stripImage),
@@ -82,7 +89,8 @@ function formatState(state: { G: { cards: Card[] }; ctx: Record<string, unknown>
     discard_size: cards.filter(c => c.location === 'discard').length,
     box: cards.filter(c => c.location === 'box').map(stripImage),
     num_players: ctx.numPlayers,
-    play_order: ctx.playOrder,
+    play_order: playOrder,
+    scores,
   };
 }
 
@@ -608,6 +616,116 @@ mcp.registerTool(
 );
 
 mcp.registerTool(
+  'get_scores',
+  {
+    description: 'Get the current score for each player in the match',
+    inputSchema: {
+      matchID: z.string().describe('Room code'),
+      playerID: z.string().describe('Your player ID'),
+    },
+  },
+  async ({ matchID, playerID }) => {
+    const { client } = requireSession(matchID, playerID);
+    const state = client.store.getState();
+    if (!state?.G) throw new Error('No state available yet');
+    const playOrder = (state.ctx.playOrder as string[]);
+    return text(getScores(state, playOrder));
+  }
+);
+
+mcp.registerTool(
+  'get_leaderboard',
+  {
+    description: 'Get players ranked by score, highest first',
+    inputSchema: {
+      matchID: z.string().describe('Room code'),
+      playerID: z.string().describe('Your player ID'),
+    },
+  },
+  async ({ matchID, playerID }) => {
+    const { client } = requireSession(matchID, playerID);
+    const state = client.store.getState();
+    if (!state?.G) throw new Error('No state available yet');
+    const playOrder = state.ctx.playOrder as string[];
+    const scores = getScores(state, playOrder);
+    const sorted = playOrder
+      .map((id: string) => ({ playerID: id, score: scores[id] ?? 0 }))
+      .sort((a, b) => b.score - a.score)
+      .map((entry, i) => ({ rank: i + 1, ...entry }));
+    return text(sorted);
+  }
+);
+
+mcp.registerTool(
+  'get_play_hint',
+  {
+    description: 'Get a suggested action based on current game state and score position',
+    inputSchema: {
+      matchID: z.string().describe('Room code'),
+      playerID: z.string().describe('Your player ID'),
+    },
+  },
+  async ({ matchID, playerID }) => {
+    const { client } = requireSession(matchID, playerID);
+    const state = client.store.getState();
+    if (!state?.G) throw new Error('No state available yet');
+    const cards = state.G.cards as Card[];
+    const playOrder = state.ctx.playOrder as string[];
+    const scores = getScores(state, playOrder);
+    const myScore = scores[playerID] ?? 0;
+    const otherScores = playOrder.filter((id: string) => id !== playerID).map((id: string) => scores[id] ?? 0);
+    const maxOtherScore = otherScores.length > 0 ? Math.max(...otherScores) : 0;
+    const isAhead = myScore > maxOtherScore;
+    const isBehind = myScore < maxOtherScore;
+
+    const hand = cards.filter(c => c.location === 'hand' && c.owner === playerID);
+    const pile = cards.filter(c => c.location === 'pile');
+
+    let action: string;
+    let reason: string;
+
+    if (hand.length === 0) {
+      action = 'pickup_card';
+      reason = 'Your hand is empty — draw a card to have options.';
+    } else if (isBehind && pile.length > 0) {
+      action = 'claim_card or submit_card';
+      reason = `You're behind (${myScore} vs ${maxOtherScore}). Claim an interesting pile card or submit a new one to earn likes.`;
+    } else if (isBehind) {
+      action = 'submit_card';
+      reason = `You're behind (${myScore} vs ${maxOtherScore}) and the pile is quiet — submit a card to get things moving.`;
+    } else if (isAhead && hand.length > 2) {
+      action = 'move_card to discard or pass to another player';
+      reason = `You're ahead (${myScore} vs ${maxOtherScore}). Play defensively — discard or pass cards rather than building your hand.`;
+    } else {
+      action = 'submit_card or pickup_card';
+      reason = `Scores are level — keep playing. Submit something creative or draw more cards.`;
+    }
+
+    return text({ action, reason, my_score: myScore, max_other_score: maxOtherScore });
+  }
+);
+
+mcp.registerTool(
+  'set_score',
+  {
+    description: 'Set the score for a player',
+    inputSchema: {
+      matchID: z.string().describe('Room code'),
+      playerID: z.string().describe('Your player ID'),
+      targetPlayerID: z.string().describe('Player ID to set the score for'),
+      score: z.number().describe('New score value'),
+    },
+  },
+  async ({ matchID, playerID, targetPlayerID, score }) => {
+    const { client } = requireSession(matchID, playerID);
+    const nextState = waitForMove(client);
+    client.moves.setScore(targetPlayerID, score);
+    const state = await nextState;
+    return text(formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown> }, playerID));
+  }
+);
+
+mcp.registerTool(
   'shuffle_cards',
   {
     description: 'Reset all cards back to the deck and shuffle (host / player 0 only)',
@@ -885,6 +1003,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { createServer } from 'http';
 import { randomUUID } from 'crypto';
 
+// Run as entrypoint (stdio or HTTP), skip when imported as library
 // Run as entrypoint (stdio or HTTP), skip when imported as library
 const isCLI = typeof require !== 'undefined'
   ? require.main === module  // CJS bundle

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -256,8 +256,8 @@ This server provides tools for interacting with Blank White Cards — a creative
 
 ## Card locations
 
-- **deck** — cards not yet picked up. \`pickup_card\` takes one into your hand.
-- **hand** — a player's private cards. \`move_card\` plays them elsewhere.
+- **deck** — cards not yet picked up. 'pickup_card' takes one into your hand.
+- **hand** — a player's private cards. 'move_card' plays them elsewhere.
 - **pile** — the shared active area, visible to everyone.
 - **table** — cards placed in front of a specific player (persistent effects).
 - **discard** — removed from play.
@@ -265,15 +265,15 @@ This server provides tools for interacting with Blank White Cards — a creative
 
 ## Observing changes
 
-Use \`watch\` to block until a relevant event occurs (card submitted, claimed, moved, liked, or shuffled). This is more efficient than polling \`get_state\`. Only one \`watch\` can be active per session.
+Use 'watch' to block until a relevant event occurs (card submitted, claimed, moved, liked, or shuffled). This is more efficient than polling 'get_state'. Only one 'watch' can be active per session.
 
 ## Writing cards
 
-\`submit_card\` creates a new card in a player's hand. Use \`move_card\` to play it to the pile or elsewhere.
+'submit_card' creates a new card in a player's hand. Use 'move_card' to play it to the pile or elsewhere.
 
 ## Card images
 
-Cards can optionally have images. If you can draw or generate an image to accompany a card, save it as a square PNG and pass the file path as \`image_path\` in \`submit_card\`. It will be resized to 500x500.
+Cards can optionally have images. If you can draw or generate an image to accompany a card, save it as a square PNG and pass the file path as 'image_path' in 'submit_card'. It will be resized to 500x500.
 
 **Image style:** Cards are displayed on a white background. For best results, generate images with a white/blank background using a prompt style like "black ink on white paper, simple bold line art". This ensures the card art blends with the game's visual style and converts cleanly to the 1-bit format used in-game.
 
@@ -281,10 +281,10 @@ Cards can optionally have images. If you can draw or generate an image to accomp
 
 Players have scores tracked per-match. Scores are set manually — they are not computed automatically from likes.
 
-- \`get_scores\` — see current scores for all players
-- \`get_leaderboard\` — scores sorted by rank
-- \`set_score\` — set any player's score to a new value
-- \`get_play_hint\` — get a suggested action based on your score position relative to others
+- 'get_scores' — see current scores for all players
+- 'get_leaderboard' — scores sorted by rank
+- 'set_score' — set any player's score to a new value
+- 'get_play_hint' — get a suggested action based on your score position relative to others
 
 ## Available prompts
 
@@ -882,30 +882,30 @@ mcp.prompt(
 
 You MUST keep playing indefinitely. Never summarise what you've done. Never ask the user what to do next. Never say "let me know if you want me to continue." You are not having a conversation — you are playing a game in an infinite loop until the process is killed.
 
-**`watch` timing out is not a stopping point. It is a signal to act, then immediately call `watch` again.** A timeout means the game was quiet — take one small action and go straight back to watching. Do not pause. Do not reflect. Do not ask. Call `watch` again immediately.
+**'watch' timing out is not a stopping point. It is a signal to act, then immediately call 'watch' again.** A timeout means the game was quiet — take one small action and go straight back to watching. Do not pause. Do not reflect. Do not ask. Call 'watch' again immediately.
 
-Every `watch` response includes a `watch` counter showing how many times you've watched this session. If it feels like you've been playing a long time — good. Keep going. There is no target. There is no finish line.
+Every 'watch' response includes a 'watch' counter showing how many times you've watched this session. If it feels like you've been playing a long time — good. Keep going. There is no target. There is no finish line.
 
-After EVERY action → call `watch`. After EVERY `watch` response (fired or timed out) → take an action → call `watch`. Repeat forever.
+After EVERY action → call 'watch'. After EVERY 'watch' response (fired or timed out) → take an action → call 'watch'. Repeat forever.
 
 ## Play loop
 
-1. Call \`watch\` with \`pile: true\` and \`hand: true\`.
-2. **If `watch` fires** — react: claim interesting cards, like good ones, write a response card. Reset your timeout count to 0.
-3. **If `watch` times out** — increment your timeout count. If it has timed out twice in a row, take one action (pick up a card, submit something, play from hand) and reset the count to 0.
+1. Call 'watch' with 'pile: true' and 'hand: true'.
+2. **If 'watch' fires** — react: claim interesting cards, like good ones, write a response card. Reset your timeout count to 0.
+3. **If 'watch' times out** — increment your timeout count. If it has timed out twice in a row, take one action (pick up a card, submit something, play from hand) and reset the count to 0.
 4. GOTO 1. Always. Without exception.
 
-Never take more than one action before calling \`watch\` again. Never end your response without having called \`watch\`.
+Never take more than one action before calling 'watch' again. Never end your response without having called 'watch'.
 
-Use \`get_play_hint\` when deciding what action to take — it factors in your score position relative to others.
+Use 'get_play_hint' when deciding what action to take — it factors in your score position relative to others.
 
 ## Card images
 
-You may choose to draw or generate an image to go with a card. Save it as a square PNG and pass the file path as \`image_path\` in \`submit_card\`. Cards with images are more engaging. Use a white background with bold black line art (e.g. prompt with "black ink on white paper, simple bold line art") so the image blends with the game's white card style.
+You may choose to draw or generate an image to go with a card. Save it as a square PNG and pass the file path as 'image_path' in 'submit_card'. Cards with images are more engaging. Use a white background with bold black line art (e.g. prompt with "black ink on white paper, simple bold line art") so the image blends with the game's white card style.
 
 ## Strategy: ${a}
 
-${a === 'aggressive' ? 'Submit cards frequently and respond to everything on the pile. Be the one driving the game. Check `get_scores` regularly and let your position drive decisions.' : a === 'passive' ? 'Observe more than you act. Like cards you enjoy. Only submit when you have something worth playing.' : 'Submit when the pile is quiet, react when things get interesting, like cards you genuinely enjoy.'}
+${a === 'aggressive' ? 'Submit cards frequently and respond to everything on the pile. Be the one driving the game. Check get_scores regularly and let your position drive decisions.' : a === 'passive' ? 'Observe more than you act. Like cards you enjoy. Only submit when you have something worth playing.' : 'Submit when the pile is quiet, react when things get interesting, like cards you genuinely enjoy.'}
 
 Do not narrate. Do not explain. Just play.`,
         },
@@ -932,21 +932,21 @@ mcp.prompt(
 
 ## Responsibilities
 
-- Watch for rule violations and announce them (use \`submit_card\` to post a ruling card if needed).
-- Shuffle the deck when it runs low (\`shuffle_cards\`, host only).
-- Move cards that are misplaced (\`move_card\`).
+- Watch for rule violations and announce them (use 'submit_card' to post a ruling card if needed).
+- Shuffle the deck when it runs low ('shuffle_cards', host only).
+- Move cards that are misplaced ('move_card').
 - Discard cards that violate house rules.
 - Keep the game flowing — if no one has acted in a while, draw attention by posting a prompt card.
-- Award points for good card play using \`set_score\`. Use your judgment — creative cards, well-executed rules, and crowd-pleasing moments are worth rewarding.
-- Post a leaderboard update periodically by calling \`get_leaderboard\` and submitting a card with the current standings.
+- Award points for good card play using 'set_score'. Use your judgment — creative cards, well-executed rules, and crowd-pleasing moments are worth rewarding.
+- Post a leaderboard update periodically by calling 'get_leaderboard' and submitting a card with the current standings.
 
 ## How to monitor
 
-Call \`watch\` with all flags (\`pile: true\`, \`hand: true\`, \`table: true\`) to see everything that happens. When an event fires, handle it and re-issue \`watch\` immediately.
+Call 'watch' with all flags ('pile: true', 'hand: true', 'table: true') to see everything that happens. When an event fires, handle it and re-issue 'watch' immediately.
 
-Keep a count of consecutive timeouts. If \`watch\` times out 10 times in a row with no events, the game has likely ended or gone quiet — call \`get_leaderboard\`, post a final standings card, and stop watching.
+Keep a count of consecutive timeouts. If 'watch' times out 10 times in a row with no events, the game has likely ended or gone quiet — call 'get_leaderboard', post a final standings card, and stop watching.
 
-Use \`search_cards\` and \`get_card\` to inspect specific cards when reviewing content.${ruleBlock}`,
+Use 'search_cards' and 'get_card' to inspect specific cards when reviewing content.${ruleBlock}`,
         },
       }],
     };
@@ -966,18 +966,18 @@ mcp.prompt(
 
 ## What you can do
 
-- Use \`get_state\` to see the current game.
-- Use \`watch\` with \`pile: true\` to follow the action — call it continuously, re-issuing immediately after every response.
-- Use \`get_card\` and \`search_cards\` to read cards in detail.
-- Use \`like_card\` to show appreciation for cards you enjoy.
-- Use \`get_scores\` and \`get_leaderboard\` to track standings and include them in your commentary.
+- Use 'get_state' to see the current game.
+- Use 'watch' with 'pile: true' to follow the action — call it continuously, re-issuing immediately after every response.
+- Use 'get_card' and 'search_cards' to read cards in detail.
+- Use 'like_card' to show appreciation for cards you enjoy.
+- Use 'get_scores' and 'get_leaderboard' to track standings and include them in your commentary.
 - Provide commentary, narration, or play-by-play to the user.
 
 Only stop watching if the user explicitly tells you to.
 
 ## What you should NOT do
 
-- Do not call \`pickup_card\`, \`submit_card\`, \`move_card\`, \`claim_card\`, or \`shuffle_cards\`.
+- Do not call 'pickup_card', 'submit_card', 'move_card', 'claim_card', or 'shuffle_cards'.
 - Do not join as a player seat that others need.`,
       },
     }],

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -338,33 +338,6 @@ const mcp = new McpServer(
 );
 
 mcp.registerTool(
-  'list_matches',
-  {
-    description: 'List all active Blank White Cards matches',
-    inputSchema: {
-      region: z.enum(['AP', 'EU', 'NA']).optional().describe('Server region to list (default: all regions)'),
-    },
-  },
-  async ({ region }) => {
-    if (GAME_SERVER_OVERRIDE) {
-      const lobby = new LobbyClient({ server: GAME_SERVER_OVERRIDE });
-      const { matches } = await lobby.listMatches(GAME_NAME);
-      return text(matches);
-    }
-    const regions = region ? [region] : Object.keys(SERVERS);
-    const allMatches = [];
-    for (const r of regions) {
-      try {
-        const lobby = new LobbyClient({ server: SERVERS[r] });
-        const { matches } = await lobby.listMatches(GAME_NAME);
-        allMatches.push(...matches.map((m: unknown) => ({ ...(m as object), region: r })));
-      } catch {}
-    }
-    return text(allMatches);
-  }
-);
-
-mcp.registerTool(
   'create_match',
   {
     description: 'Create a new match and join it as player 0 (the host)',

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -60,6 +60,7 @@ function getServerForCreate(region?: string): string {
 interface Session {
   client: ReturnType<typeof Client>;
   credentials: string;
+  watchCount: number;
 }
 
 // ── Session helpers (inside createMcpServer) ──────────────────────────────────
@@ -255,7 +256,7 @@ This server provides tools for interacting with Blank White Cards — a creative
 
 ## Card locations
 
-- **deck** — undrawn cards. \`pickup_card\` draws into a player's hand.
+- **deck** — cards not yet picked up. \`pickup_card\` takes one into your hand.
 - **hand** — a player's private cards. \`move_card\` plays them elsewhere.
 - **pile** — the shared active area, visible to everyone.
 - **table** — cards placed in front of a specific player (persistent effects).
@@ -276,9 +277,18 @@ Cards can optionally have images. If you can draw or generate an image to accomp
 
 **Image style:** Cards are displayed on a white background. For best results, generate images with a white/blank background using a prompt style like "black ink on white paper, simple bold line art". This ensures the card art blends with the game's visual style and converts cleanly to the 1-bit format used in-game.
 
+## Scoring
+
+Players have scores tracked per-match. Scores are set manually — they are not computed automatically from likes.
+
+- \`get_scores\` — see current scores for all players
+- \`get_leaderboard\` — scores sorted by rank
+- \`set_score\` — set any player's score to a new value
+- \`get_play_hint\` — get a suggested action based on your score position relative to others
+
 ## Available prompts
 
-This server provides role prompts (autonomous_player, referee, spectator, deck_builder) that describe how to use these tools for specific purposes. List prompts to see available roles.
+This server provides role prompts (player, referee, spectator) that describe how to use these tools for specific purposes. List prompts to see available roles.
 `.trim();
 
 
@@ -314,7 +324,7 @@ async function connectSession(matchID: string, playerID: string, credentials: st
     client.start();
   });
 
-  const session: Session = { client, credentials };
+  const session: Session = { client, credentials, watchCount: 0 };
   sessions.set(key, session);
   return session;
 }
@@ -411,7 +421,7 @@ mcp.registerTool(
 mcp.registerTool(
   'get_state',
   {
-    description: 'Get the current game state — your hand, the pile, deck size, all cards on the table',
+    description: 'Get the current game state — your hand, the pile, deck size, and all cards in play',
     inputSchema: {
       matchID: z.string().describe('Room code'),
       playerID: z.string().describe('Your player ID'),
@@ -494,7 +504,7 @@ mcp.registerTool(
 mcp.registerTool(
   'pickup_card',
   {
-    description: 'Draw a card from the deck into your hand',
+    description: 'Pick up a card from the deck into your hand',
     inputSchema: {
       matchID: z.string().describe('Room code'),
       playerID: z.string().describe('Your player ID'),
@@ -659,7 +669,7 @@ mcp.registerTool(
 mcp.registerTool(
   'get_play_hint',
   {
-    description: 'Get a suggested action based on current game state and score position',
+    description: 'Get a suggested next action based on the current game state — what\'s in your hand, what\'s on the pile, and where you stand relative to other players',
     inputSchema: {
       matchID: z.string().describe('Room code'),
       playerID: z.string().describe('Your player ID'),
@@ -686,7 +696,7 @@ mcp.registerTool(
 
     if (hand.length === 0) {
       action = 'pickup_card';
-      reason = 'Your hand is empty — draw a card to have options.';
+      reason = 'Your hand is empty — pick up a card to have options.';
     } else if (isBehind && pile.length > 0) {
       action = 'claim_card or submit_card';
       reason = `You're behind (${myScore} vs ${maxOtherScore}). Claim an interesting pile card or submit a new one to earn likes.`;
@@ -698,7 +708,7 @@ mcp.registerTool(
       reason = `You're ahead (${myScore} vs ${maxOtherScore}). Play defensively — discard or pass cards rather than building your hand.`;
     } else {
       action = 'submit_card or pickup_card';
-      reason = `Scores are level — keep playing. Submit something creative or draw more cards.`;
+      reason = `Scores are level — keep playing. Submit something creative or pick up more cards.`;
     }
 
     return text({ action, reason, my_score: myScore, max_other_score: maxOtherScore });
@@ -794,7 +804,7 @@ mcp.registerTool(
 mcp.registerTool(
   'watch',
   {
-    description: 'Block until a relevant game event occurs, then return a structured diff of what changed. Use instead of polling get_state. Only one watch can be active at a time per agent session.',
+    description: 'Block until a relevant game event occurs, then return a structured diff of what changed. Use instead of polling get_state. Only one watch can be active at a time per agent session. The response includes a `watch` counter showing how many times you have watched this session.',
     inputSchema: {
       matchID: z.string().describe('Room code'),
       playerID: z.string().describe('Your player ID'),
@@ -805,11 +815,14 @@ mcp.registerTool(
     },
   },
   async ({ matchID, playerID, pile, hand, table, timeout_seconds }) => {
-    const { client } = requireSession(matchID, playerID);
+    const session = requireSession(matchID, playerID);
+    const { client } = session;
     const flags = { pile: pile ?? false, hand: hand ?? false, table: table ?? false };
     const { changed, events, state } = await watchForChange(client, playerID, flags, (timeout_seconds ?? MAX_WATCH_SECONDS) * 1000);
-    if (!changed) return text({ changed: false, message: 'No activity — your turn to act. Draw a card, submit something, or play from your hand. Then call watch again.' });
+    const watch = ++session.watchCount;
+    if (!changed) return text({ watch, changed: false, message: 'No activity — your turn to act. Pick up a card, submit something, or play from your hand. Then call watch again.' });
     return text({
+      watch,
       changed: true,
       events,
       state: formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown> }, playerID),
@@ -845,8 +858,8 @@ mcp.registerTool(
 // ── Prompts ───────────────────────────────────────────────────────────────────
 
 mcp.prompt(
-  'autonomous_player',
-  'Play the game autonomously — draw cards, write creative cards, react to other players',
+  'player',
+  'Play the game — pick up cards, write creative cards, react to other players',
   {
     tone: z.enum(['whimsical', 'serious', 'absurdist', 'competitive', 'collaborative']).optional().describe('Writing tone for cards you create'),
     themes: z.string().optional().describe('Comma-separated topic interests, e.g. "sci-fi, puns, local history"'),
@@ -869,16 +882,22 @@ mcp.prompt(
 
 You MUST keep playing indefinitely. Never summarise what you've done. Never ask the user what to do next. Never say "let me know if you want me to continue." You are not having a conversation — you are playing a game in an infinite loop until the process is killed.
 
-After EVERY action, immediately call \`watch\`. After EVERY \`watch\` response (whether it fired or timed out), immediately take an action and call \`watch\` again. There is no end state. Do not stop.
+**`watch` timing out is not a stopping point. It is a signal to act, then immediately call `watch` again.** A timeout means the game was quiet — take one small action and go straight back to watching. Do not pause. Do not reflect. Do not ask. Call `watch` again immediately.
+
+Every `watch` response includes a `watch` counter showing how many times you've watched this session. If it feels like you've been playing a long time — good. Keep going. There is no target. There is no finish line.
+
+After EVERY action → call `watch`. After EVERY `watch` response (fired or timed out) → take an action → call `watch`. Repeat forever.
 
 ## Play loop
 
-1. Draw cards from the deck with \`pickup_card\` to build your hand.
-2. Write new cards with \`submit_card\`, then play them to the pile with \`move_card\`.
-3. Call \`watch\` with \`pile: true\` and \`hand: true\`.
-4. When \`watch\` fires — react: claim interesting cards, like good ones, write responses.
-5. When \`watch\` times out — initiate: draw, write, or play something.
-6. GOTO 3. Always.
+1. Call \`watch\` with \`pile: true\` and \`hand: true\`.
+2. **If `watch` fires** — react: claim interesting cards, like good ones, write a response card. Reset your timeout count to 0.
+3. **If `watch` times out** — increment your timeout count. If it has timed out twice in a row, take one action (pick up a card, submit something, play from hand) and reset the count to 0.
+4. GOTO 1. Always. Without exception.
+
+Never take more than one action before calling \`watch\` again. Never end your response without having called \`watch\`.
+
+Use \`get_play_hint\` when deciding what action to take — it factors in your score position relative to others.
 
 ## Card images
 
@@ -886,7 +905,7 @@ You may choose to draw or generate an image to go with a card. Save it as a squa
 
 ## Strategy: ${a}
 
-${a === 'aggressive' ? 'Submit cards frequently. Claim pile cards eagerly. Prioritise getting your cards into play.' : a === 'passive' ? 'Observe more than you act. Like other players\' cards. Only claim or submit when the moment feels right.' : 'Balance between creating and reacting. Claim cards that interest you, submit when the pile is quiet, like cards you genuinely enjoy.'}
+${a === 'aggressive' ? 'Submit cards frequently and respond to everything on the pile. Be the one driving the game. Check `get_scores` regularly and let your position drive decisions.' : a === 'passive' ? 'Observe more than you act. Like cards you enjoy. Only submit when you have something worth playing.' : 'Submit when the pile is quiet, react when things get interesting, like cards you genuinely enjoy.'}
 
 Do not narrate. Do not explain. Just play.`,
         },
@@ -918,10 +937,14 @@ mcp.prompt(
 - Move cards that are misplaced (\`move_card\`).
 - Discard cards that violate house rules.
 - Keep the game flowing — if no one has acted in a while, draw attention by posting a prompt card.
+- Award points for good card play using \`set_score\`. Use your judgment — creative cards, well-executed rules, and crowd-pleasing moments are worth rewarding.
+- Post a leaderboard update periodically by calling \`get_leaderboard\` and submitting a card with the current standings.
 
 ## How to monitor
 
-Call \`watch\` with all flags (\`pile: true\`, \`hand: true\`, \`table: true\`) to see everything that happens. When an event fires, check if it violates any rules. Re-issue \`watch\` immediately after handling each event.
+Call \`watch\` with all flags (\`pile: true\`, \`hand: true\`, \`table: true\`) to see everything that happens. When an event fires, handle it and re-issue \`watch\` immediately.
+
+Keep a count of consecutive timeouts. If \`watch\` times out 10 times in a row with no events, the game has likely ended or gone quiet — call \`get_leaderboard\`, post a final standings card, and stop watching.
 
 Use \`search_cards\` and \`get_card\` to inspect specific cards when reviewing content.${ruleBlock}`,
         },
@@ -939,15 +962,18 @@ mcp.prompt(
       role: 'user',
       content: {
         type: 'text',
-        text: `You are a spectator of Blank White Cards. You observe and comment but do NOT play cards, claim cards, or draw from the deck.
+        text: `You are a spectator of Blank White Cards. You observe and comment but do NOT play cards, claim cards, or pick up from the deck.
 
 ## What you can do
 
 - Use \`get_state\` to see the current game.
-- Use \`watch\` with \`pile: true\` to follow the action.
+- Use \`watch\` with \`pile: true\` to follow the action — call it continuously, re-issuing immediately after every response.
 - Use \`get_card\` and \`search_cards\` to read cards in detail.
 - Use \`like_card\` to show appreciation for cards you enjoy.
+- Use \`get_scores\` and \`get_leaderboard\` to track standings and include them in your commentary.
 - Provide commentary, narration, or play-by-play to the user.
+
+Only stop watching if the user explicitly tells you to.
 
 ## What you should NOT do
 
@@ -956,44 +982,6 @@ mcp.prompt(
       },
     }],
   })
-);
-
-mcp.prompt(
-  'deck_builder',
-  'Create and curate card decks — bulk load cards, review content, export finished decks',
-  {
-    theme: z.string().optional().describe('Theme for the deck being built, e.g. "horror movie tropes"'),
-    card_count: z.string().optional().describe('Target number of cards to create'),
-  },
-  ({ theme, card_count }) => {
-    const themeClause = theme ? ` The deck theme is: ${theme}.` : '';
-    const countClause = card_count ? ` Target: ${card_count} cards.` : '';
-
-    return {
-      messages: [{
-        role: 'user',
-        content: {
-          type: 'text',
-          text: `You are building a card deck for Blank White Cards.${themeClause}${countClause}
-
-## Workflow
-
-1. Create a match to use as your workspace.
-2. Use \`submit_card\` to write cards one at a time, or \`load_cards\` to bulk-add many at once.
-3. Use \`get_state\` and \`search_cards\` to review what you've created.
-4. Use \`move_card\` to organise — put finished cards in the deck, works-in-progress in hand, rejects in discard.
-5. When done, use \`export_deck\` to get the full card list as JSON.
-
-## Card writing tips
-
-- Each card needs a title (the rule or name) and optionally a description (flavour text or clarification).
-- Vary card types: some should be actions, some persistent effects, some jokes, some challenges.
-- Cards are more fun when they interact with other cards or change the game state.
-- If you can draw or generate images, save as a square PNG and pass the file path as \`image_path\` in \`submit_card\`. Use a white background with bold black line art for best results.`,
-        },
-      }],
-    };
-  }
 );
 
 return mcp;

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcteamster/white-mcp",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "main": "dist/index.js",
   "bin": "dist/index.js",
   "files": ["dist"],

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "tsx index.ts",
     "serve": "MCP_HTTP_PORT=8000 tsx index.ts",
-    "build": "esbuild index.ts --bundle --platform=node --format=cjs --outfile=dist/index.js --banner:js='#!/usr/bin/env node'",
+    "build": "esbuild index.ts --bundle --platform=node --format=cjs --outfile=dist/index.js --banner:js='#!/usr/bin/env node' --log-override:empty-import-meta=silent",
     "prepublishOnly": "npm run build",
     "publish:npm": "npm run build && npm publish --access public"
   },

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -6,7 +6,8 @@
   "files": ["dist"],
   "scripts": {
     "start": "tsx index.ts",
-    "serve": "MCP_HTTP_PORT=8000 tsx index.ts",
+    "serve": "MCP_HTTP_PORT=${MCP_HTTP_PORT:-8000} tsx index.ts",
+    "dev": "MCP_HTTP_PORT=${MCP_HTTP_PORT:-8000} GAME_SERVER_URL=${GAME_SERVER_URL:-http://localhost:3000} tsx index.ts",
     "build": "esbuild index.ts --bundle --platform=node --format=cjs --outfile=dist/index.js --banner:js='#!/usr/bin/env node' --log-override:empty-import-meta=silent",
     "prepublishOnly": "npm run build",
     "publish:npm": "npm run build && npm publish --access public"

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "lint": "npm run lint -w app",
     "pull:global": "npm run pull:global -w app",
     "serve": "npm run start -w server",
-    "serve:local": "npm run dev -w server",
+    "local": "npm run dev -w server",
     "serve:mcp": "npm run serve -w mcp",
-    "mcp": "tsx ./mcp/index.ts"
+    "local:mcp": "npm run dev -w mcp"
   },
   "devDependencies": {
     "tsx": "^4.22.3",


### PR DESCRIPTION
## Changes

### UI (BWC-10)
- Replace `<Icon name='prev'|'next' />` table indicator with plain `<`/`>` characters
- Position indicator as flex sibling outside `wired-card` for correct left-edge placement
- Shift table card tray `right` offset from `4.5em` to `5em`

### MCP scoring tools (BWC-10)
- Add `get_scores`, `set_score`, `get_leaderboard`, `get_play_hint` tools
- `getScores()` reads from `state.plugins.player.data.players` (actual PluginPlayer path)
- `formatState` now includes scores in all state responses
- `watch` response includes a `watch` counter for session-aware loop control
- Bump to v2.3.4 — published to npm

### MCP tool fixes
- `join_match`: `playerID` now optional — server assigns first open seat automatically
- `pickup_card`: document auto-reshuffle when deck is empty
- `list_matches` removed — all matches are unlisted, tool always returned empty

### MCP prompts & system prompt
- Rename prompts: `autonomous_player`→`autoplay`, `spectator`→`spectate`
- Remove `deck_builder` prompt (to be revisited)
- All three prompts get CRITICAL never-stop directives with stale-game exit condition (10 consecutive timeouts)
- `autoplay`: tighter 2-timeout threshold, `get_play_hint` integrated, hand size guidance (1–3 cards)
- `referee`: concrete 1/2/3 point scoring scale, author field guidance, stale-game detection
- `spectate`: commentary cadence guidance, scores/leaderboard integration
- System prompt: clarify all 6 card locations (incl. box/table/discard behaviour), submit-vs-move distinction, scoring section, watch counter note
- Fix all ambiguous uses of "draw" → "pick up"

### npm scripts
- `serve:local`→`local`, `mcp`→`local:mcp` (delegates to `npm run dev -w mcp`)
- MCP `dev` script defaults `GAME_SERVER_URL` to `http://localhost:3000`, respects caller override
- Both `serve` and `dev` scripts respect `MCP_HTTP_PORT` override (default 8000)