### PR TITLE
feat: chat log, game console, and MCP chat tools (BWC-11/36/12)

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcteamster/white-api",
-  "version": "2.3.6",
+  "version": "2.3.8",
   "scripts": {
     "build": "tsc",
     "cdk": "cdk"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcteamster/white-app",
   "private": true,
-  "version": "2.3.6",
+  "version": "2.3.8",
   "scripts": {
     "dev": "vite --host",
     "build": "tsc -b && vite build",

--- a/app/src/Board.tsx
+++ b/app/src/Board.tsx
@@ -10,7 +10,7 @@ import { discordSdk } from './lib/discord.ts';
 
 // Web Components from https://wiredjs.com/
 import 'wired-elements';
-import { useReducer } from 'react';
+import { useReducer, useState } from 'react';
 import { ImageCacheContext, ImageCacheType } from './lib/contexts.ts';
 declare global {
   namespace React.JSX {
@@ -44,14 +44,32 @@ export function BlankWhiteCardsBoard(props: BoardProps<GameState>) {
     return cache
   }, {})
 
+  // Mutual exclusion on mobile: chat and players tray can't both be open
+  const [showPlayers, setShowPlayers] = useState(!dimensions.upright);
+  const [chatOpen, setChatOpen] = useState(false);
+
+  const isMobile = dimensions.width < 600;
+
+  const handleSetShowPlayers: React.Dispatch<React.SetStateAction<boolean>> = (value) => {
+    const next = typeof value === 'function' ? value(showPlayers) : value;
+    if (next && isMobile) setChatOpen(false);
+    setShowPlayers(next);
+  };
+
+  const handleSetChatOpen: React.Dispatch<React.SetStateAction<boolean>> = (value) => {
+    const next = typeof value === 'function' ? value(chatOpen) : value;
+    if (next && isMobile) setShowPlayers(false);
+    setChatOpen(next);
+  };
+
   return (
     <ImageCacheContext.Provider value={{ imageCache, dispatchImage }}>
       <div style={boardStyle}>
         <ActionSpace {...props} />
-        <CommonSpace {...props} />
+        <CommonSpace {...props} showPlayers={showPlayers} setShowPlayers={handleSetShowPlayers} />
         <PlayerSpace {...props} />
       </div>
-      {props.isMultiplayer && <Console {...props} playerName={props.matchData?.find(p => p.id === Number(props.playerID))?.name} />}
+      {props.isMultiplayer && <Console {...props} playerName={props.matchData?.find(p => p.id === Number(props.playerID))?.name} open={chatOpen} setOpen={handleSetChatOpen} />}
     </ImageCacheContext.Provider>
   );
 }

--- a/app/src/Board.tsx
+++ b/app/src/Board.tsx
@@ -4,6 +4,7 @@ import type { Properties } from 'csstype';
 import { ActionSpace } from './Components/ActionSpace.tsx';
 import { CommonSpace } from './Components/CommonSpace.tsx';
 import { PlayerSpace } from './Components/PlayerSpace.tsx';
+import { Console } from './Components/Console.tsx';
 import { useWindowDimensions } from './lib/hooks.ts';
 import { discordSdk } from './lib/discord.ts';
 
@@ -50,6 +51,7 @@ export function BlankWhiteCardsBoard(props: BoardProps<GameState>) {
         <CommonSpace {...props} />
         <PlayerSpace {...props} />
       </div>
+      <Console {...props} playerName={props.matchData?.find(p => p.id === Number(props.playerID))?.name} />
     </ImageCacheContext.Provider>
   );
 }

--- a/app/src/Board.tsx
+++ b/app/src/Board.tsx
@@ -51,7 +51,7 @@ export function BlankWhiteCardsBoard(props: BoardProps<GameState>) {
         <CommonSpace {...props} />
         <PlayerSpace {...props} />
       </div>
-      <Console {...props} playerName={props.matchData?.find(p => p.id === Number(props.playerID))?.name} />
+      {props.isMultiplayer && <Console {...props} playerName={props.matchData?.find(p => p.id === Number(props.playerID))?.name} />}
     </ImageCacheContext.Provider>
   );
 }

--- a/app/src/Components/ActionSpace.tsx
+++ b/app/src/Components/ActionSpace.tsx
@@ -231,7 +231,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
       bottom: '0',
       left: '50%',
       transform: 'translate(-50%, 0%)',
-      zIndex: '8',
+      zIndex: '30',
       display: 'flex',
       flexDirection: 'row',
       justifyContent: 'space-around',
@@ -341,7 +341,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
     </>
   } else if (mode === 'create-sketch') {
     topRow = (
-      <div style={{ position: 'fixed', top: 'calc(2em + 12px)', left: '50%', transform: 'translateX(-50%)', zIndex: 10, display: 'flex', justifyContent: 'space-around', width: '100%', maxWidth: '40em' }}>
+      <div style={{ position: 'fixed', top: 'calc(2em + 12px)', left: '50%', transform: 'translateX(-50%)', zIndex: 50, display: 'flex', justifyContent: 'space-around', width: '100%', maxWidth: '40em' }}>
         <wired-card style={{ ...styles.button, color: 'red' }} onClick={() => { fillWhite(); setDrawMode(getMode()); }} elevation={2}><Icon name='discard' />Clear</wired-card>
         <wired-card style={{ ...styles.button, color: drawMode === MODE_ERASE ? 'red' : undefined }} onClick={() => {
           const newMode = drawMode === MODE_ERASE ? MODE_DRAW : MODE_ERASE;

--- a/app/src/Components/ActionSpace.tsx
+++ b/app/src/Components/ActionSpace.tsx
@@ -124,7 +124,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
         }
 
         // Update Gamestate
-        moves.submitCard(createdCard);
+        moves.submitCard(createdCard, matchData?.find(p => p.id == Number(playerID))?.name);
         setMode('play');
 
         // Cleanup creation elements in background

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -98,7 +98,7 @@ export function Players(props: BoardProps<GameState>) {
       overflowY: 'scroll',
       scrollbarWidth: 'none',
       position: 'fixed',
-      top: (discordSdk && dimensions.upright) ? '4.75em' : '2em',
+      top: (discordSdk && dimensions.upright) ? '4.75em' : '4.5em',
       right: '0',
       zIndex: '20',
       borderRadius: '0 0 0 1em',
@@ -246,9 +246,6 @@ export function Header(props: HeaderProps) {
       flexDirection: 'row',
       padding: '0 0.25em',
     },
-    displayname: {
-      fontSize: '1em',
-    },
     match: {
       fontSize: '1.25em',
     },
@@ -258,25 +255,53 @@ export function Header(props: HeaderProps) {
     <>
       <div style={styles.header}>
         <div style={{ ...styles.item, ...styles.match }} onClick={ () => setShowShare(true) }><Icon name='copy' />&nbsp;{props.matchID !== 'default' ? `${props.matchID}` : "Blank White Cards"}</div>
-        <div style={{ ...styles.item, ...styles.displayname }} onClick={() => { props.setShowPlayers(!props.showPlayers) }}>
-          {playerName && (editingMyScore ? (
-            <Calculator
-              initialValue={myScore}
-              label={playerName || undefined}
-              onConfirm={(val) => { props.moves.setScore(props.playerID || '0', val); setEditingMyScore(false); }}
-              onCancel={() => setEditingMyScore(false)}
-            />
-          ) : (
-            <>{playerName}&nbsp;<span
-              style={{ fontVariantNumeric: 'tabular-nums', cursor: 'pointer', textDecoration: 'underline dotted' }}
-              onClick={(e) => { e.stopPropagation(); setEditingMyScore(true); }}
-            >{formatScore(myScore)} pts</span></>
-          ))}&nbsp;
-          {props.matchID !== 'default' && <Icon name='multi' />}&nbsp;
-          {props.matchData?.filter((player => player.isConnected)).length}
-          {props.matchID !== 'default' && (props.matchData?.filter((player => player.isConnected)).length != 1) ? ((props.showPlayers) ? <Icon name='less' /> : <Icon name='more' />) : <>&nbsp;</> }
-        </div>
+        {props.isMultiplayer && props.matchID !== 'default' && (
+          <div style={{ ...styles.item, fontSize: '1em' }}>
+            {playerName && (editingMyScore ? (
+              <Calculator
+                initialValue={myScore}
+                label={playerName || undefined}
+                onConfirm={(val) => { props.moves.setScore(props.playerID || '0', val); setEditingMyScore(false); }}
+                onCancel={() => setEditingMyScore(false)}
+              />
+            ) : (
+              <>{playerName}&nbsp;<span
+                style={{ fontVariantNumeric: 'tabular-nums', cursor: 'pointer', textDecoration: 'underline dotted' }}
+                onClick={(e) => { e.stopPropagation(); setEditingMyScore(true); }}
+              >{formatScore(myScore)} pts</span></>
+            ))}
+          </div>
+        )}
       </div>
+      {/* Player tray notch — people icon + count + toggle, top-right */}
+      {props.isMultiplayer && props.matchID !== 'default' && (props.matchData?.filter(p => p.isConnected).length ?? 0) > 1 && (
+        <div style={{
+          position: 'fixed',
+          top: (discordSdk && dimensions.upright) ? '4.75em' : '2em',
+          right: '0',
+          zIndex: 40,
+          cursor: 'pointer',
+        }} onClick={() => { props.setShowPlayers(!props.showPlayers) }}>
+          <div style={{
+            backgroundColor: 'white',
+            padding: '0.25em 0.5em',
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: '0.25em',
+            borderRadius: '0 0 0 1em',
+            border: '1px solid #ccc',
+            borderTop: 'none',
+            borderRight: 'none',
+            userSelect: 'none' as const,
+            fontSize: '0.9em',
+          }}>
+            <Icon name='multi' />
+            {props.matchData?.filter(p => p.isConnected).length}
+            {props.showPlayers ? <Icon name='less' /> : <Icon name='more' />}
+          </div>
+        </div>
+      )}
       {showShare && <ShareRoom matchID={props.matchID} setShowShare={setShowShare} />}
     </>
   )

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -51,7 +51,7 @@ export function Pile(props: BoardProps<GameState>) {
         }
       }} style={{ position: 'relative' }}>
         {pile.length > 0 && (
-          <div style={{ position: 'absolute', bottom: '1.25em', right: '1.75em', zIndex: 1 }}>
+          <div style={{ position: 'absolute', bottom: '1.25em', right: '1.75em', zIndex: 10 }}>
             <Likes card={pile[0]} likeCard={props.moves.likeCard} matchId={props.matchID} />
           </div>
         )}
@@ -100,7 +100,7 @@ export function Players(props: BoardProps<GameState>) {
       position: 'fixed',
       top: (discordSdk && dimensions.upright) ? '4.75em' : '2em',
       right: '0',
-      zIndex: '4',
+      zIndex: '20',
       borderRadius: '0 0 0 1em',
       display: 'flex',
       flexDirection: 'column',
@@ -134,7 +134,7 @@ export function Players(props: BoardProps<GameState>) {
       scrollbarWidth: 'none',
       margin: '0.25em',
       borderRadius: '0.5em',
-      zIndex: '5',
+      zIndex: '20',
       position: (dimensions.upright) ? 'fixed' : 'relative',
       right: (dimensions.upright) ? '5em' : undefined,
       backgroundColor: (dimensions.upright) ? 'rgba(0, 0, 0, 0.5)' : 'rgba(255, 255, 255, 0.5)',
@@ -233,7 +233,7 @@ export function Header(props: HeaderProps) {
       position: 'fixed',
       top: '0',
       left: '0',
-      zIndex: '10',
+      zIndex: '50',
       backgroundColor: 'white',
       borderBottom: '0.5pt solid black',
       display: 'flex',
@@ -310,7 +310,7 @@ export function ShareRoom(props: { matchID: string, setShowShare: React.Dispatch
       position: 'fixed',
       top: '0',
       left: '0',
-      zIndex: '9',
+      zIndex: '40',
       backgroundColor: 'white',
       borderBottom: '0.5pt solid black',
       display: 'flex',

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -204,7 +204,7 @@ export function Players(props: BoardProps<GameState>) {
         <Calculator
           initialValue={getPlayerScore(props.plugins, String(editingScore))}
           label={props.matchData?.find(p => p.id === editingScore)?.name}
-          onConfirm={(val) => { props.moves.setScore(String(editingScore), val); setEditingScore(null); }}
+          onConfirm={(val) => { props.moves.setScore(String(editingScore), val, props.matchData?.find(p => p.id === Number(props.playerID))?.name, props.matchData?.find(p => p.id === editingScore)?.name); setEditingScore(null); }}
           onCancel={() => setEditingScore(null)}
         />
       )}
@@ -261,7 +261,7 @@ export function Header(props: HeaderProps) {
               <Calculator
                 initialValue={myScore}
                 label={playerName || undefined}
-                onConfirm={(val) => { props.moves.setScore(props.playerID || '0', val); setEditingMyScore(false); }}
+                onConfirm={(val) => { props.moves.setScore(props.playerID || '0', val, playerName, playerName); setEditingMyScore(false); }}
                 onCancel={() => setEditingMyScore(false)}
               />
             ) : (

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -98,7 +98,7 @@ export function Players(props: BoardProps<GameState>) {
       overflowY: 'scroll',
       scrollbarWidth: 'none',
       position: 'fixed',
-      top: (discordSdk && dimensions.upright) ? '4.75em' : '4.5em',
+      top: (discordSdk && dimensions.upright) ? '4.75em' : '4em',
       right: '0',
       zIndex: '20',
       borderRadius: '0 0 0 1em',
@@ -256,7 +256,7 @@ export function Header(props: HeaderProps) {
       <div style={styles.header}>
         <div style={{ ...styles.item, ...styles.match }} onClick={ () => setShowShare(true) }><Icon name='copy' />&nbsp;{props.matchID !== 'default' ? `${props.matchID}` : "Blank White Cards"}</div>
         {props.isMultiplayer && props.matchID !== 'default' && (
-          <div style={{ ...styles.item, fontSize: '1em' }}>
+          <div style={{ ...styles.item, fontSize: '1em', paddingRight: '0.5em' }}>
             {playerName && (editingMyScore ? (
               <Calculator
                 initialValue={myScore}
@@ -296,9 +296,8 @@ export function Header(props: HeaderProps) {
             userSelect: 'none' as const,
             fontSize: '0.9em',
           }}>
-            <Icon name='multi' />
             {props.matchData?.filter(p => p.isConnected).length}
-            {props.showPlayers ? <Icon name='less' /> : <Icon name='more' />}
+            <Icon name='multi' />
           </div>
         </div>
       )}

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -370,9 +370,16 @@ export function ShareRoom(props: { matchID: string, setShowShare: React.Dispatch
   )
 }
 
-export function CommonSpace(props: BoardProps<GameState>) {
+interface CommonSpaceProps extends BoardProps<GameState> {
+  showPlayers?: boolean;
+  setShowPlayers?: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export function CommonSpace(props: CommonSpaceProps) {
   const dimensions = useWindowDimensions();
-  const [showPlayers, setShowPlayers] = useState(!(dimensions.upright));
+  const [localShowPlayers, setLocalShowPlayers] = useState(!(dimensions.upright));
+  const showPlayers = props.showPlayers ?? localShowPlayers;
+  const setShowPlayers = props.setShowPlayers ?? setLocalShowPlayers;
 
   return (
     <>

--- a/app/src/Components/Console.tsx
+++ b/app/src/Components/Console.tsx
@@ -83,7 +83,10 @@ export function Console({ moves, playerID, playerName, plugins }: ConsoleProps) 
       flexDirection: 'row',
       alignItems: 'center',
       gap: '0.25em',
-      borderRadius: '0 0 1em 1em',
+      borderRadius: '0 0 1em 0',
+      border: '1px solid #ccc',
+      borderTop: 'none',
+      borderLeft: 'none',
       cursor: 'pointer',
       userSelect: 'none' as const,
       fontSize: '0.9em',
@@ -106,10 +109,11 @@ export function Console({ moves, playerID, playerName, plugins }: ConsoleProps) 
     panel: {
       position: 'fixed',
       top: `calc(${headerHeight} + 2.5em)`,
-      left: '0',
+      left: '0.5em',
       zIndex: 40,
-      width: '320px',
-      maxHeight: '40vh',
+      width: 'calc(100vw - 1.25em)',
+      maxWidth: '480px',
+      maxHeight: '70vh',
       display: 'flex',
       flexDirection: 'column',
       border: '2px solid #333',
@@ -118,24 +122,28 @@ export function Console({ moves, playerID, playerName, plugins }: ConsoleProps) 
       boxShadow: '0 2px 8px rgba(0,0,0,0.2)',
     },
     list: {
-      overflowY: 'auto',
+      overflowY: 'scroll',
+      scrollbarWidth: 'none',
       flex: 1,
-      padding: '0.5em',
+      padding: '0.5em 0.5em 0.5em 0.75em',
       fontSize: '0.8em',
     },
     inputRow: {
       display: 'flex',
+      alignItems: 'center',
       borderTop: '1px solid #ccc',
-      padding: '0.25em',
+      padding: '0.25em 0.5em',
       gap: '0.25em',
     },
     chatMsg: {
       marginBottom: '0.3em',
+      wordBreak: 'break-all',
     },
     eventMsg: {
       marginBottom: '0.3em',
       fontStyle: 'italic',
       color: '#888',
+      wordBreak: 'break-all',
     },
   };
 
@@ -144,11 +152,23 @@ export function Console({ moves, playerID, playerName, plugins }: ConsoleProps) 
       {/* Toggle button */}
       <div style={styles.toggle} onClick={open ? () => setOpen(false) : handleOpen}>
         <div style={styles.toggleIcon}>
-          <Icon name='chat' />
-          Chat
-          {!open && unread > 0 && (
-            <span style={styles.badge}>{unread > 9 ? '9+' : unread}</span>
-          )}
+          <span style={{ position: 'relative', display: 'inline-flex' }}>
+            <Icon name='chat' />
+            {!open && unread > 0 && (
+              <span style={{ position: 'absolute', top: '40%', left: '50%', transform: 'translate(-50%, -50%)', fontSize: '0.75em', fontWeight: 'bold' }}>{unread > 9 ? '9+' : unread}</span>
+            )}
+          </span>
+          {open
+            ? 'Close Chat'
+            : !open && messages.length > 0
+            ? <span style={{ maxWidth: '180px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {messages[messages.length - 1].type === 'chat'
+                  ? <><strong>{messages[messages.length - 1].playerName || `Player ${messages[messages.length - 1].playerID}`}:</strong> {messages[messages.length - 1].text}</>
+                  : messages[messages.length - 1].text
+                }
+              </span>
+            : 'Chat'
+          }
         </div>
       </div>
 
@@ -173,13 +193,13 @@ export function Console({ moves, playerID, playerName, plugins }: ConsoleProps) 
             <wired-input
               id="consoleInput"
               placeholder="Say something..."
-              maxlength={500}
-              style={{ flex: 1, fontSize: '0.8em' }}
+              maxlength={100}
+              style={{ flex: 1, fontSize: '0.8em', padding: '0.6em' }}
             ></wired-input>
             <wired-button
               onClick={sendMessage}
-              style={{ fontSize: '0.8em' }}
-            >Send</wired-button>
+              style={{ backgroundColor: '#eee' }}
+            ><Icon name='send' /></wired-button>
           </div>
         </div>
       )}

--- a/app/src/Components/Console.tsx
+++ b/app/src/Components/Console.tsx
@@ -1,0 +1,153 @@
+import type { BoardProps } from 'boardgame.io/react';
+import type { GameState, Message } from '@mcteamster/white-core';
+import type { Properties } from 'csstype';
+import { useEffect, useRef, useState } from 'react';
+
+interface ConsoleProps extends BoardProps<GameState> {
+  playerName?: string;
+}
+
+export function Console({ moves, playerID, playerName, plugins }: ConsoleProps) {
+  const messages: Message[] = (plugins as any)?.chat?.data?.messages ?? [];
+  const [open, setOpen] = useState(false);
+  const [unread, setUnread] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+  const prevLenRef = useRef(messages.length);
+
+  // Auto-scroll to bottom when new messages arrive
+  useEffect(() => {
+    if (open && listRef.current) {
+      listRef.current.scrollTop = listRef.current.scrollHeight;
+    }
+  }, [messages.length, open]);
+
+  // Track unread when closed
+  useEffect(() => {
+    if (!open && messages.length > prevLenRef.current) {
+      setUnread(u => u + (messages.length - prevLenRef.current));
+    }
+    prevLenRef.current = messages.length;
+  }, [messages.length, open]);
+
+  const handleOpen = () => {
+    setOpen(true);
+    setUnread(0);
+    // Scroll to bottom after opening
+    setTimeout(() => {
+      if (listRef.current) listRef.current.scrollTop = listRef.current.scrollHeight;
+    }, 0);
+  };
+
+  const styles: { [key: string]: Properties<string | number> } = {
+    toggle: {
+      position: 'fixed',
+      bottom: '1em',
+      right: '1em',
+      zIndex: 100,
+      cursor: 'pointer',
+      fontSize: '1.25em',
+      userSelect: 'none',
+    },
+    badge: {
+      position: 'absolute',
+      top: '-0.5em',
+      right: '-0.5em',
+      background: '#e74c3c',
+      color: 'white',
+      borderRadius: '50%',
+      width: '1.2em',
+      height: '1.2em',
+      fontSize: '0.7em',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      fontWeight: 'bold',
+    },
+    panel: {
+      position: 'fixed',
+      bottom: '3.5em',
+      right: '1em',
+      zIndex: 100,
+      width: '320px',
+      maxHeight: '40vh',
+      display: 'flex',
+      flexDirection: 'column',
+      border: '2px solid #333',
+      borderRadius: '0.5em',
+      background: 'white',
+      boxShadow: '0 2px 8px rgba(0,0,0,0.2)',
+    },
+    list: {
+      overflowY: 'auto',
+      flex: 1,
+      padding: '0.5em',
+      fontSize: '0.8em',
+    },
+    inputRow: {
+      display: 'flex',
+      borderTop: '1px solid #ccc',
+      padding: '0.25em',
+      gap: '0.25em',
+    },
+    chatMsg: {
+      marginBottom: '0.3em',
+    },
+    eventMsg: {
+      marginBottom: '0.3em',
+      fontStyle: 'italic',
+      color: '#888',
+    },
+  };
+
+  return (
+    <>
+      {/* Toggle button */}
+      <div style={styles.toggle} onClick={open ? () => setOpen(false) : handleOpen}>
+        <span style={{ position: 'relative', display: 'inline-block' }}>
+          💬
+          {!open && unread > 0 && (
+            <span style={styles.badge}>{unread > 9 ? '9+' : unread}</span>
+          )}
+        </span>
+      </div>
+
+      {/* Panel */}
+      {open && (
+        <div style={styles.panel}>
+          <div ref={listRef} style={styles.list}>
+            {messages.length === 0 && (
+              <div style={{ color: '#aaa', fontStyle: 'italic' }}>No messages yet</div>
+            )}
+            {messages.map(msg => (
+              <div key={msg.id} style={msg.type === 'chat' ? styles.chatMsg : styles.eventMsg}>
+                {msg.type === 'chat' ? (
+                  <><strong>{msg.playerName || `Player ${msg.playerID}`}:</strong> {msg.text}</>
+                ) : (
+                  <>{msg.text}</>
+                )}
+              </div>
+            ))}
+          </div>
+          <div style={styles.inputRow}>
+            <wired-input
+              id="consoleInput"
+              placeholder="Say something..."
+              maxlength={500}
+              style={{ flex: 1, fontSize: '0.8em' }}
+            ></wired-input>
+            <wired-button
+              onClick={() => {
+                const el = document.getElementById('consoleInput') as HTMLInputElement & { value: string };
+                const text = el?.value?.trim();
+                if (!text || !playerID) return;
+                moves.postMessage(text, playerName);
+                el.value = '';
+              }}
+              style={{ fontSize: '0.8em' }}
+            >Send</wired-button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/src/Components/Console.tsx
+++ b/app/src/Components/Console.tsx
@@ -132,7 +132,6 @@ export function Console({ moves, playerID, playerName, plugins, matchData, open:
       scrollbarWidth: 'none',
       flex: 1,
       padding: '0.5em 0.5em 0.5em 0.75em',
-      fontSize: '0.8em',
       display: 'flex',
       flexDirection: 'column',
       justifyContent: 'flex-end',
@@ -146,13 +145,13 @@ export function Console({ moves, playerID, playerName, plugins, matchData, open:
     },
     chatMsg: {
       marginBottom: '0.3em',
-      wordBreak: 'break-all',
+      overflowWrap: 'break-word',
     },
     eventMsg: {
       marginBottom: '0.3em',
       fontStyle: 'italic',
       color: '#888',
-      wordBreak: 'break-all',
+      overflowWrap: 'break-word',
     },
   };
 
@@ -208,14 +207,17 @@ export function Console({ moves, playerID, playerName, plugins, matchData, open:
           <div style={styles.inputRow}>
             <wired-input
               id="consoleInput"
-              placeholder="Say something..."
+              placeholder="All chat - visible to everyone"
               maxlength={500}
-              style={{ flex: 1, fontSize: '0.8em' }}
+              style={{ flex: 1 }}
             ></wired-input>
             <wired-button
               onClick={sendMessage}
               style={{ backgroundColor: '#eee' }}
             ><Icon name='send' /></wired-button>
+          </div>
+          <div style={{ padding: '0 0 0.25em 0', fontSize: '0.8em', color: '#aaa', textAlign: 'center' }}>
+            Do not share personal information.
           </div>
         </div>
       )}

--- a/app/src/Components/Console.tsx
+++ b/app/src/Components/Console.tsx
@@ -91,20 +91,19 @@ export function Console({ moves, playerID, playerName, plugins }: ConsoleProps) 
       userSelect: 'none' as const,
       fontSize: '0.9em',
     },
-    badge: {
+    unreadCount: {
       position: 'absolute',
-      top: '-0.5em',
-      right: '-0.5em',
-      background: '#e74c3c',
-      color: 'white',
-      borderRadius: '50%',
-      width: '1.2em',
-      height: '1.2em',
-      fontSize: '0.7em',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
+      top: '40%',
+      left: '50%',
+      transform: 'translate(-50%, -50%)',
+      fontSize: '0.75em',
       fontWeight: 'bold',
+    },
+    previewText: {
+      maxWidth: '180px',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
     },
     panel: {
       position: 'fixed',
@@ -155,13 +154,13 @@ export function Console({ moves, playerID, playerName, plugins }: ConsoleProps) 
           <span style={{ position: 'relative', display: 'inline-flex' }}>
             <Icon name='chat' />
             {!open && unread > 0 && (
-              <span style={{ position: 'absolute', top: '40%', left: '50%', transform: 'translate(-50%, -50%)', fontSize: '0.75em', fontWeight: 'bold' }}>{unread > 9 ? '9+' : unread}</span>
+              <span style={styles.unreadCount}>{unread > 9 ? '9+' : unread}</span>
             )}
           </span>
           {open
             ? 'Close Chat'
             : !open && messages.length > 0
-            ? <span style={{ maxWidth: '180px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            ? <span style={styles.previewText}>
                 {messages[messages.length - 1].type === 'chat'
                   ? <><strong>{messages[messages.length - 1].playerName || `Player ${messages[messages.length - 1].playerID}`}:</strong> {messages[messages.length - 1].text}</>
                   : messages[messages.length - 1].text
@@ -193,8 +192,8 @@ export function Console({ moves, playerID, playerName, plugins }: ConsoleProps) 
             <wired-input
               id="consoleInput"
               placeholder="Say something..."
-              maxlength={100}
-              style={{ flex: 1, fontSize: '0.8em', padding: '0.6em' }}
+              maxlength={500}
+              style={{ flex: 1, fontSize: '0.8em' }}
             ></wired-input>
             <wired-button
               onClick={sendMessage}

--- a/app/src/Components/Console.tsx
+++ b/app/src/Components/Console.tsx
@@ -10,7 +10,7 @@ interface ConsoleProps extends BoardProps<GameState> {
   playerName?: string;
 }
 
-export function Console({ moves, playerID, playerName, plugins }: ConsoleProps) {
+export function Console({ moves, playerID, playerName, plugins, matchData }: ConsoleProps) {
   const messages: Message[] = (plugins as any)?.chat?.data?.messages ?? [];
   const dimensions = useWindowDimensions();
   const headerHeight = (discordSdk && dimensions.upright) ? '4.75em' : '2em';
@@ -33,6 +33,8 @@ export function Console({ moves, playerID, playerName, plugins }: ConsoleProps) 
     }
     prevLenRef.current = messages.length;
   }, [messages.length, open]);
+
+  const resolveName = (id?: string) => matchData?.find(p => p.id === Number(id))?.name || `Player ${id}`;
 
   const sendMessage = () => {
     const el = document.getElementById('consoleInput') as HTMLInputElement & { value: string };
@@ -100,7 +102,7 @@ export function Console({ moves, playerID, playerName, plugins }: ConsoleProps) 
       fontWeight: 'bold',
     },
     previewText: {
-      maxWidth: '180px',
+      maxWidth: '240px',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
@@ -160,10 +162,12 @@ export function Console({ moves, playerID, playerName, plugins }: ConsoleProps) 
           {open
             ? 'Close Chat'
             : !open && messages.length > 0
-            ? <span style={styles.previewText}>
+            ? <span style={{ ...styles.previewText, ...(messages[messages.length - 1].type === 'event' ? { fontStyle: 'italic', color: '#888' } : {}) }}>
                 {messages[messages.length - 1].type === 'chat'
-                  ? <><strong>{messages[messages.length - 1].playerName || `Player ${messages[messages.length - 1].playerID}`}:</strong> {messages[messages.length - 1].text}</>
-                  : messages[messages.length - 1].text
+                  ? <><strong>{messages[messages.length - 1].playerName || resolveName(messages[messages.length - 1].playerID)}:</strong> {messages[messages.length - 1].text}</>
+                  : messages[messages.length - 1].playerID
+                    ? <><strong>{resolveName(messages[messages.length - 1].playerID)}</strong> {messages[messages.length - 1].targetPlayerID ? messages[messages.length - 1].text.replace('{recipient}', resolveName(messages[messages.length - 1].targetPlayerID)) : messages[messages.length - 1].text}</>
+                    : messages[messages.length - 1].text
                 }
               </span>
             : 'Chat'
@@ -181,9 +185,9 @@ export function Console({ moves, playerID, playerName, plugins }: ConsoleProps) 
             {messages.map(msg => (
               <div key={msg.id} style={msg.type === 'chat' ? styles.chatMsg : styles.eventMsg}>
                 {msg.type === 'chat' ? (
-                  <><strong>{msg.playerName || `Player ${msg.playerID}`}:</strong> {msg.text}</>
+                  <><strong>{msg.playerName || resolveName(msg.playerID)}:</strong> {msg.text}</>
                 ) : (
-                  <>{msg.text}</>
+                  <>{msg.playerID ? <><strong>{resolveName(msg.playerID)}</strong> {msg.targetPlayerID ? msg.text.replace('{recipient}', resolveName(msg.targetPlayerID)) : msg.text}</> : msg.text}</>
                 )}
               </div>
             ))}

--- a/app/src/Components/Console.tsx
+++ b/app/src/Components/Console.tsx
@@ -2,6 +2,9 @@ import type { BoardProps } from 'boardgame.io/react';
 import type { GameState, Message } from '@mcteamster/white-core';
 import type { Properties } from 'csstype';
 import { useEffect, useRef, useState } from 'react';
+import { Icon } from './Icons';
+import { discordSdk } from '../lib/discord';
+import { useWindowDimensions } from '../lib/hooks';
 
 interface ConsoleProps extends BoardProps<GameState> {
   playerName?: string;
@@ -9,6 +12,8 @@ interface ConsoleProps extends BoardProps<GameState> {
 
 export function Console({ moves, playerID, playerName, plugins }: ConsoleProps) {
   const messages: Message[] = (plugins as any)?.chat?.data?.messages ?? [];
+  const dimensions = useWindowDimensions();
+  const headerHeight = (discordSdk && dimensions.upright) ? '4.75em' : '2em';
   const [open, setOpen] = useState(false);
   const [unread, setUnread] = useState(0);
   const listRef = useRef<HTMLDivElement>(null);
@@ -29,6 +34,28 @@ export function Console({ moves, playerID, playerName, plugins }: ConsoleProps) 
     prevLenRef.current = messages.length;
   }, [messages.length, open]);
 
+  const sendMessage = () => {
+    const el = document.getElementById('consoleInput') as HTMLInputElement & { value: string };
+    const text = el?.value?.trim();
+    if (!text || !playerID) return;
+    moves.postMessage(text, playerName);
+    el.value = '';
+  };
+
+  // Attach Enter key listener to the wired-input's shadow DOM input
+  useEffect(() => {
+    if (!open) return;
+    const timer = setTimeout(() => {
+      const inp = document.getElementById('consoleInput')?.shadowRoot?.querySelector('input');
+      if (!inp) return;
+      const handler = (e: Event) => { if ((e as KeyboardEvent).key === 'Enter') sendMessage(); };
+      inp.addEventListener('keydown', handler);
+      return () => inp.removeEventListener('keydown', handler);
+    }, 50);
+    return () => clearTimeout(timer);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
   const handleOpen = () => {
     setOpen(true);
     setUnread(0);
@@ -41,12 +68,25 @@ export function Console({ moves, playerID, playerName, plugins }: ConsoleProps) 
   const styles: { [key: string]: Properties<string | number> } = {
     toggle: {
       position: 'fixed',
-      bottom: '1em',
-      right: '1em',
-      zIndex: 100,
+      top: headerHeight,
+      left: '0',
+      zIndex: 40,
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'flex-start',
+      alignItems: 'center',
+    },
+    toggleIcon: {
+      backgroundColor: 'white',
+      padding: '0.25em 0.5em',
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: '0.25em',
+      borderRadius: '0 0 1em 1em',
       cursor: 'pointer',
-      fontSize: '1.25em',
-      userSelect: 'none',
+      userSelect: 'none' as const,
+      fontSize: '0.9em',
     },
     badge: {
       position: 'absolute',
@@ -65,9 +105,9 @@ export function Console({ moves, playerID, playerName, plugins }: ConsoleProps) 
     },
     panel: {
       position: 'fixed',
-      bottom: '3.5em',
-      right: '1em',
-      zIndex: 100,
+      top: `calc(${headerHeight} + 2.5em)`,
+      left: '0',
+      zIndex: 40,
       width: '320px',
       maxHeight: '40vh',
       display: 'flex',
@@ -103,12 +143,13 @@ export function Console({ moves, playerID, playerName, plugins }: ConsoleProps) 
     <>
       {/* Toggle button */}
       <div style={styles.toggle} onClick={open ? () => setOpen(false) : handleOpen}>
-        <span style={{ position: 'relative', display: 'inline-block' }}>
-          💬
+        <div style={styles.toggleIcon}>
+          <Icon name='chat' />
+          Chat
           {!open && unread > 0 && (
             <span style={styles.badge}>{unread > 9 ? '9+' : unread}</span>
           )}
-        </span>
+        </div>
       </div>
 
       {/* Panel */}
@@ -136,13 +177,7 @@ export function Console({ moves, playerID, playerName, plugins }: ConsoleProps) 
               style={{ flex: 1, fontSize: '0.8em' }}
             ></wired-input>
             <wired-button
-              onClick={() => {
-                const el = document.getElementById('consoleInput') as HTMLInputElement & { value: string };
-                const text = el?.value?.trim();
-                if (!text || !playerID) return;
-                moves.postMessage(text, playerName);
-                el.value = '';
-              }}
+              onClick={sendMessage}
               style={{ fontSize: '0.8em' }}
             >Send</wired-button>
           </div>

--- a/app/src/Components/Console.tsx
+++ b/app/src/Components/Console.tsx
@@ -8,13 +8,18 @@ import { useWindowDimensions } from '../lib/hooks';
 
 interface ConsoleProps extends BoardProps<GameState> {
   playerName?: string;
+  open?: boolean;
+  setOpen?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export function Console({ moves, playerID, playerName, plugins, matchData }: ConsoleProps) {
+export function Console({ moves, playerID, playerName, plugins, matchData, open: openProp, setOpen: setOpenProp }: ConsoleProps) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const messages: Message[] = (plugins as any)?.chat?.data?.messages ?? [];
   const dimensions = useWindowDimensions();
   const headerHeight = (discordSdk && dimensions.upright) ? '4.75em' : '2em';
-  const [open, setOpen] = useState(false);
+  const [localOpen, setLocalOpen] = useState(false);
+  const open = openProp ?? localOpen;
+  const setOpen = setOpenProp ?? setLocalOpen;
   const [unread, setUnread] = useState(0);
   const listRef = useRef<HTMLDivElement>(null);
   const prevLenRef = useRef(messages.length);
@@ -55,7 +60,6 @@ export function Console({ moves, playerID, playerName, plugins, matchData }: Con
       return () => inp.removeEventListener('keydown', handler);
     }, 50);
     return () => clearTimeout(timer);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
   const handleOpen = () => {
@@ -170,7 +174,7 @@ export function Console({ moves, playerID, playerName, plugins, matchData }: Con
                     : messages[messages.length - 1].text
                 }
               </span>
-            : 'Chat'
+            : null
           }
         </div>
       </div>
@@ -179,9 +183,6 @@ export function Console({ moves, playerID, playerName, plugins, matchData }: Con
       {open && (
         <div style={styles.panel}>
           <div ref={listRef} style={styles.list}>
-            {messages.length === 0 && (
-              <div style={{ color: '#aaa', fontStyle: 'italic' }}>No messages yet</div>
-            )}
             {messages.map(msg => (
               <div key={msg.id} style={msg.type === 'chat' ? styles.chatMsg : styles.eventMsg}>
                 {msg.type === 'chat' ? (

--- a/app/src/Components/Console.tsx
+++ b/app/src/Components/Console.tsx
@@ -21,6 +21,7 @@ export function Console({ moves, playerID, playerName, plugins, matchData, open:
   const open = openProp ?? localOpen;
   const setOpen = setOpenProp ?? setLocalOpen;
   const [unread, setUnread] = useState(0);
+  const [showEvents, setShowEvents] = useState(true);
   const listRef = useRef<HTMLDivElement>(null);
   const prevLenRef = useRef(messages.length);
 
@@ -118,7 +119,7 @@ export function Console({ moves, playerID, playerName, plugins, matchData, open:
       zIndex: 40,
       width: 'calc(100vw - 1.25em)',
       maxWidth: '480px',
-      maxHeight: '70vh',
+      height: '70vh',
       display: 'flex',
       flexDirection: 'column',
       border: '2px solid #333',
@@ -132,6 +133,9 @@ export function Console({ moves, playerID, playerName, plugins, matchData, open:
       flex: 1,
       padding: '0.5em 0.5em 0.5em 0.75em',
       fontSize: '0.8em',
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'flex-end',
     },
     inputRow: {
       display: 'flex',
@@ -182,9 +186,17 @@ export function Console({ moves, playerID, playerName, plugins, matchData, open:
       {/* Panel */}
       {open && (
         <div style={styles.panel}>
+          <div style={{ position: 'absolute', top: '0.25em', right: '0.5em', zIndex: 1, fontSize: '0.75em' }}>
+            <span
+              onClick={() => setShowEvents(v => !v)}
+              style={{ cursor: 'pointer', color: showEvents ? '#888' : '#bbb', userSelect: 'none' }}
+            >
+              events <Icon name={showEvents ? 'show' : 'hide'} />
+            </span>
+          </div>
           <div ref={listRef} style={styles.list}>
-            {messages.map(msg => (
-              <div key={msg.id} style={msg.type === 'chat' ? styles.chatMsg : styles.eventMsg}>
+            {messages.filter(msg => showEvents || msg.type === 'chat').map((msg, i) => (
+              <div key={`${msg.id}-${i}`} style={msg.type === 'chat' ? styles.chatMsg : styles.eventMsg}>
                 {msg.type === 'chat' ? (
                   <><strong>{msg.playerName || resolveName(msg.playerID)}:</strong> {msg.text}</>
                 ) : (

--- a/app/src/Components/Editor/CardEditor.tsx
+++ b/app/src/Components/Editor/CardEditor.tsx
@@ -148,7 +148,7 @@ export function CardEditor({ onSave, onCancel, editingCard, onShowDrawingControl
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
-      zIndex: 1000
+      zIndex: 60
     },
     finalise: {
       width: '100%',
@@ -156,7 +156,7 @@ export function CardEditor({ onSave, onCancel, editingCard, onShowDrawingControl
       position: 'fixed' as const,
       top: '0',
       left: '0',
-      zIndex: '7',
+      zIndex: '20',
       textAlign: 'center' as const,
       display: 'flex',
       flexDirection: 'column' as const,

--- a/app/src/Components/Editor/DeckEditor.tsx
+++ b/app/src/Components/Editor/DeckEditor.tsx
@@ -71,7 +71,7 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
       top: '20px',
       left: '50%',
       transform: 'translateX(-50%)',
-      zIndex: 10,
+      zIndex: 50,
       display: 'flex',
       justifyContent: 'space-around',
       width: '100%',
@@ -82,7 +82,7 @@ function DrawingControls({ onBack, onUndo, onRedo, onCancel }: {
       bottom: '20px',
       left: '50%',
       transform: 'translateX(-50%)',
-      zIndex: 10,
+      zIndex: 50,
       display: 'flex',
       justifyContent: 'space-around',
       width: '100%',
@@ -361,7 +361,7 @@ export function DeckEditor() {
       flexDirection: 'column',
       alignItems: 'center',
       gap: '1em',
-      zIndex: 5
+      zIndex: 20
     },
     actionButtons: {
       display: 'flex', 
@@ -412,7 +412,7 @@ export function DeckEditor() {
       display: 'flex', 
       justifyContent: 'center', 
       alignItems: 'center',
-      zIndex: 1000
+      zIndex: 60
     },
     dialogCard: {
       backgroundColor: 'white', 
@@ -445,7 +445,7 @@ export function DeckEditor() {
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
-      zIndex: 1000
+      zIndex: 60
     },
     fileModal: {
       backgroundColor: 'white',
@@ -1013,7 +1013,7 @@ export function DeckEditor() {
                     <input
                       ref={fileInputRef}
                       type="file"
-                      accept=".html"
+                      accept=".html,.json"
                       onChange={handleFileLoad}
                       style={styles.hiddenInput}
                     />

--- a/app/src/Components/Finalise.tsx
+++ b/app/src/Components/Finalise.tsx
@@ -13,7 +13,7 @@ export function Finalise({ multiplayer }: FinaliseProps) {
       position: 'fixed',
       top: '0',
       left: '0',
-      zIndex: '7',
+      zIndex: '30',
       textAlign: 'center',
       display: 'none',
       flexDirection: 'column',

--- a/app/src/Components/Focus.tsx
+++ b/app/src/Components/Focus.tsx
@@ -291,7 +291,7 @@ export function Focus(props: BoardProps<GameState>) {
             top: 0,
             left: 0,
             width: '100vw',
-            zIndex: 1001,
+            zIndex: 110,
             pointerEvents: 'auto',
           }} onClick={e => e.stopPropagation()}>
             {carousel}
@@ -391,7 +391,7 @@ export function Likes({ card, likeCard, matchId }: LikesProps) {
       width: '1.75em',
       height: '1.75em',
       position: 'absolute',
-      zIndex: '1',
+      zIndex: '10',
       top: '-1.75em',
       right: '-2.5em',
       padding: '1em',
@@ -487,7 +487,7 @@ export function Share({ id }: { id: number }) {
       width: '1.75em',
       height: '1.75em',
       position: 'absolute',
-      zIndex: '1',
+      zIndex: '10',
       top: '2.75em',
       right: '-2.5em',
       padding: '1em',

--- a/app/src/Components/Gallery.tsx
+++ b/app/src/Components/Gallery.tsx
@@ -95,7 +95,7 @@ export function Gallery() {
       position: 'fixed',
       bottom: '0',
       left: '0',
-      zIndex: '10',
+      zIndex: '50',
       backgroundColor: 'white',
       borderTop: '0.5pt solid black',
       display: 'flex',

--- a/app/src/Components/Icons.tsx
+++ b/app/src/Components/Icons.tsx
@@ -1,5 +1,6 @@
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import GrainIcon from '@mui/icons-material/Grain';
 import BackHandOutlinedIcon from '@mui/icons-material/BackHandOutlined';
@@ -53,6 +54,7 @@ type IconName =
   'about' |
   'back' |
   'book' |
+  'chat' |
   'checklist' |
   'coffee' |
   'copy' |
@@ -106,6 +108,7 @@ export function Icon(props: { name: IconName }) {
     about: <QuestionMarkOutlinedIcon></QuestionMarkOutlinedIcon>,
     back: <KeyboardBackspaceOutlinedIcon></KeyboardBackspaceOutlinedIcon>,
     book: <BookOutlinedIcon></BookOutlinedIcon>,
+    chat: <ChatBubbleOutlineIcon></ChatBubbleOutlineIcon>,
     checklist: <LibraryAddCheckOutlinedIcon></LibraryAddCheckOutlinedIcon>,
     coffee: <LocalCafeOutlinedIcon></LocalCafeOutlinedIcon>,
     copy: <ContentCopyOutlinedIcon></ContentCopyOutlinedIcon>,

--- a/app/src/Components/Icons.tsx
+++ b/app/src/Components/Icons.tsx
@@ -71,12 +71,10 @@ type IconName =
   'heart' |
   'hearted' |
   'info' |
-  'less' |
   'link' |
   'loading' |
   'logout' |
   'menu' |
-  'more' |
   'multi' |
   'next' |
   'play' |

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcteamster/white-core",
-  "version": "2.3.6",
+  "version": "2.3.8",
   "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/core/src/Cards.ts
+++ b/core/src/Cards.ts
@@ -1,4 +1,13 @@
 // Types
+export interface Message {
+  id: number;
+  type: 'chat' | 'event';
+  playerID?: string;
+  playerName?: string;
+  text: string;
+  timestamp: number;
+}
+
 export interface Card {
   id: number,
   content: {

--- a/core/src/Cards.ts
+++ b/core/src/Cards.ts
@@ -4,6 +4,7 @@ export interface Message {
   type: 'chat' | 'event';
   playerID?: string;
   playerName?: string;
+  targetPlayerID?: string;
   text: string;
   timestamp: number;
 }

--- a/core/src/Game.ts
+++ b/core/src/Game.ts
@@ -112,11 +112,11 @@ const likeCard: Move<GameState> = ({ G }, id) => {
   }
 }
 
-const submitCard: Move<GameState> = ({ G, ctx, gamelog, chat }: any, card: Card, playerName?: string) => {
+const submitCard: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, card: Card, playerName?: string) => {
   card.id = G.cards.length + 1; // Commit ID sequentially to GameState
   G.cards.push(card);
   if (ctx.numPlayers > 1) {
-    gamelog.record({ move: 'submitCard', playerID: card.owner || '', playerName, cardID: card.id, cardTitle: card.content.title.slice(0, 30) });
+    gamelog.record({ move: 'submitCard', playerID, playerName, cardID: card.id, cardTitle: card.content.title.slice(0, 30) });
     chat.syncFromLog(gamelog.entries());
   }
 }

--- a/core/src/Game.ts
+++ b/core/src/Game.ts
@@ -11,7 +11,7 @@ export interface GameState {
 }
 
 // Moves
-const pickupCard: Move<GameState> = ({ G, random, playerID }) => {
+const pickupCard: Move<GameState> = ({ G, ctx, random, playerID, chat }: any) => {
   const deck = getCardsByLocation(G.cards, "deck");
   if (deck.length === 0) {
     // Reshuffle Pile and Discard into Deck
@@ -41,12 +41,15 @@ const pickupCard: Move<GameState> = ({ G, random, playerID }) => {
     card.owner = playerID;
     card.timestamp = Number(Date.now());
     card.location = "hand";
+    if (ctx.numPlayers > 1) chat.send({ type: 'event', playerID, text: `picked up a card` });
   }
 }
 
-const moveCard: Move<GameState> = ({ G, playerID }, id, target, owner) => {
+const moveCard: Move<GameState> = ({ G, ctx, playerID, chat }: any, id, target, owner) => {
   const selectedCard = getCardById(G.cards, id);
   if (selectedCard) {
+    const sourceLocation = selectedCard.location;
+    const sourceOwner = selectedCard.owner;
     if (['pile', 'discard', 'deck'].includes(target)) {
       selectedCard.location = target;
       selectedCard.owner = undefined;
@@ -62,12 +65,34 @@ const moveCard: Move<GameState> = ({ G, playerID }, id, target, owner) => {
     } else {
       return INVALID_MOVE;
     }
+    if (ctx.numPlayers > 1) {
+      const publicLocations = ['pile', 'table'];
+      const sourcePublic = publicLocations.includes(sourceLocation);
+      const destPublic = publicLocations.includes(target);
+      const showTitle = sourcePublic || destPublic;
+      const title = showTitle ? `"${selectedCard.content.title.slice(0, 30)}"` : '';
+      const recipientID = owner && owner !== playerID ? owner : undefined;
+
+      let text: string;
+      if (recipientID && target === 'hand') {
+        text = title ? `sent to {recipient}: ${title}` : `sent a card to {recipient}`;
+      } else if (recipientID) {
+        text = title ? `→ {recipient}'s ${target}: ${title}` : `→ {recipient}'s ${target}`;
+      } else if (target === 'pile') {
+        // playing to pile — omit destination
+        text = title ? `→ ${title}` : `→ pile`;
+      } else {
+        text = title ? `→ ${target}: ${title}` : `→ ${target}`;
+      }
+
+      chat.send({ type: 'event', playerID, targetPlayerID: recipientID, text });
+    }
   } else {
     return INVALID_MOVE;
   }
 }
 
-const claimCard: Move<GameState> = ({ G, playerID }, id) => {
+const claimCard: Move<GameState> = ({ G, ctx, playerID, chat }: any, id) => {
   const selectedCard = getCardById(G.cards, id);
   if (selectedCard) {
     if (selectedCard.location == 'pile') {
@@ -75,6 +100,7 @@ const claimCard: Move<GameState> = ({ G, playerID }, id) => {
       selectedCard.owner = playerID;
       selectedCard.timestamp = Number(Date.now());
       selectedCard.location = 'hand';
+      if (ctx.numPlayers > 1) chat.send({ type: 'event', playerID, text: `← "${selectedCard.content.title.slice(0, 30)}"` });
     } else {
       return INVALID_MOVE;
     }
@@ -83,7 +109,7 @@ const claimCard: Move<GameState> = ({ G, playerID }, id) => {
   }
 }
 
-const likeCard: Move<GameState> = ({ G, ctx, chat }: any, id) => {
+const likeCard: Move<GameState> = ({ G }, id) => {
   const selectedCard = getCardById(G.cards, id);
   if (selectedCard?.likes) {
     selectedCard.likes++;
@@ -92,13 +118,12 @@ const likeCard: Move<GameState> = ({ G, ctx, chat }: any, id) => {
   } else {
     return INVALID_MOVE
   }
-  if (ctx.numPlayers > 1) chat.send({ type: 'event', text: `Card #${id} was liked` });
 }
 
-const submitCard: Move<GameState> = ({ G, ctx, chat }: any, card: Card) => {
+const submitCard: Move<GameState> = ({ G, ctx, chat }: any, card: Card, playerName?: string) => {
   card.id = G.cards.length + 1; // Commit ID sequentially to GameState
   G.cards.push(card);
-  if (ctx.numPlayers > 1) chat.send({ type: 'event', text: 'A new card was submitted' });
+  if (ctx.numPlayers > 1) chat.send({ type: 'event', text: `${playerName || 'Someone'} made a card` });
 }
 
 const loadCards: Move<GameState> = ({ G, ctx, playerID, chat }: any, cards: Card[]) => {
@@ -112,7 +137,10 @@ const loadCards: Move<GameState> = ({ G, ctx, playerID, chat }: any, cards: Card
     loadBuffer.push(card);
   })
   G.cards.push(...loadBuffer);
-  if (ctx.numPlayers > 1) chat.send({ type: 'event', text: `${cards.length} card(s) loaded into the deck` });
+  if (ctx.numPlayers > 1) {
+    const deckSize = G.cards.filter((c: Card) => c.location === 'deck').length;
+    chat.send({ type: 'event', text: `${cards.length} ${cards.length === 1 ? 'card' : 'cards'} loaded — ${deckSize} in deck` });
+  }
 }
 
 const shuffleCards: Move<GameState> = ({ G, ctx, playerID, chat }: any) => {
@@ -125,7 +153,10 @@ const shuffleCards: Move<GameState> = ({ G, ctx, playerID, chat }: any) => {
       card.timestamp = undefined;
     }
   });
-  if (ctx.numPlayers > 1) chat.send({ type: 'event', text: `Player ${playerID} shuffled the deck` });
+  if (ctx.numPlayers > 1) {
+    const deckSize = G.cards.filter((c: Card) => c.location !== 'box').length;
+    chat.send({ type: 'event', playerID, text: `shuffled — ${deckSize} in deck` });
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -136,9 +167,17 @@ const postMessage: Move<GameState> = ({ ctx, playerID, chat }: any, text: string
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const setScore: Move<GameState> = ({ player }: any, targetPlayerID: string, value: number) => {
+const setScore: Move<GameState> = ({ ctx, player, chat }: any, targetPlayerID: string, value: number, setterName?: string, targetName?: string) => {
   if (player?.state && targetPlayerID in player.state) {
+    const prev = player.state[targetPlayerID]?.score ?? 0;
     player.state[targetPlayerID] = { score: value };
+    if (ctx.numPlayers > 1) {
+      const delta = value - prev;
+      const deltaStr = delta >= 0 ? `+${delta}` : `${delta}`;
+      const who = targetName || `Player ${targetPlayerID}`;
+      const by = setterName && setterName !== targetName ? ` (by ${setterName})` : '';
+      chat.send({ type: 'event', text: `${deltaStr} pts for ${who}${by}` });
+    }
   } else {
     return INVALID_MOVE;
   }

--- a/core/src/Game.ts
+++ b/core/src/Game.ts
@@ -3,6 +3,7 @@ import { INVALID_MOVE, Stage } from 'boardgame.io/core';
 import { PluginPlayer } from 'boardgame.io/plugins';
 import { Card, getCardById, getCardsByLocation } from './Cards';
 import { presetDecks } from "./lib/constants";
+import { PluginChat } from "./lib/plugin-chat";
 
 // Game State
 export interface GameState {
@@ -82,7 +83,7 @@ const claimCard: Move<GameState> = ({ G, playerID }, id) => {
   }
 }
 
-const likeCard: Move<GameState> = ({ G }, id) => {
+const likeCard: Move<GameState> = ({ G, chat }: any, id) => {
   const selectedCard = getCardById(G.cards, id);
   if (selectedCard?.likes) {
     selectedCard.likes++;
@@ -91,14 +92,16 @@ const likeCard: Move<GameState> = ({ G }, id) => {
   } else {
     return INVALID_MOVE
   }
+  chat.send({ type: 'event', text: `Card #${id} was liked` });
 }
 
-const submitCard: Move<GameState> = ({ G }, card: Card) => {
+const submitCard: Move<GameState> = ({ G, chat }: any, card: Card) => {
   card.id = G.cards.length + 1; // Commit ID sequentially to GameState
   G.cards.push(card);
+  chat.send({ type: 'event', text: 'A new card was submitted' });
 }
 
-const loadCards: Move<GameState> = ({ G, playerID }, cards: Card[]) => {
+const loadCards: Move<GameState> = ({ G, playerID, chat }: any, cards: Card[]) => {
   if(playerID !== '0') return INVALID_MOVE; // Only the host can bulk load cards
 
   // Bulk load batches of cards
@@ -109,18 +112,26 @@ const loadCards: Move<GameState> = ({ G, playerID }, cards: Card[]) => {
     loadBuffer.push(card);
   })
   G.cards.push(...loadBuffer);
+  chat.send({ type: 'event', text: `${cards.length} card(s) loaded into the deck` });
 }
 
-const shuffleCards: Move<GameState> = ({ G, playerID }) => {
+const shuffleCards: Move<GameState> = ({ G, playerID, chat }: any) => {
   if(playerID !== '0') return INVALID_MOVE; // Only the host can reset the game
 
   // Return all cards to the deck, except those in the box
-  G.cards.forEach(card => { 
+  G.cards.forEach((card: Card) => { 
     if (card.location !== 'box') {
       card.location = 'deck'; 
       card.timestamp = undefined;
     }
   });
+  chat.send({ type: 'event', text: `Player ${playerID} shuffled the deck` });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const postMessage: Move<GameState> = ({ playerID, chat }: any, text: string, playerName?: string) => {
+  if (!text || text.length > 500) return INVALID_MOVE;
+  chat.send({ type: 'chat', playerID, playerName, text: text.trim() });
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -192,10 +203,16 @@ export const BlankWhiteCards: Game<GameState> = {
       client: false,
       ignoreStaleStateID: true,
     },
+    postMessage: {
+      move: postMessage,
+      client: false,
+      ignoreStaleStateID: true,
+    },
   },
 
   plugins: [
     PluginPlayer({ setup: () => ({ score: 0 as number }) }),
+    PluginChat(),
   ],
 
   turn: {

--- a/core/src/Game.ts
+++ b/core/src/Game.ts
@@ -83,7 +83,7 @@ const claimCard: Move<GameState> = ({ G, playerID }, id) => {
   }
 }
 
-const likeCard: Move<GameState> = ({ G, chat }: any, id) => {
+const likeCard: Move<GameState> = ({ G, ctx, chat }: any, id) => {
   const selectedCard = getCardById(G.cards, id);
   if (selectedCard?.likes) {
     selectedCard.likes++;
@@ -92,16 +92,16 @@ const likeCard: Move<GameState> = ({ G, chat }: any, id) => {
   } else {
     return INVALID_MOVE
   }
-  chat.send({ type: 'event', text: `Card #${id} was liked` });
+  if (ctx.numPlayers > 1) chat.send({ type: 'event', text: `Card #${id} was liked` });
 }
 
-const submitCard: Move<GameState> = ({ G, chat }: any, card: Card) => {
+const submitCard: Move<GameState> = ({ G, ctx, chat }: any, card: Card) => {
   card.id = G.cards.length + 1; // Commit ID sequentially to GameState
   G.cards.push(card);
-  chat.send({ type: 'event', text: 'A new card was submitted' });
+  if (ctx.numPlayers > 1) chat.send({ type: 'event', text: 'A new card was submitted' });
 }
 
-const loadCards: Move<GameState> = ({ G, playerID, chat }: any, cards: Card[]) => {
+const loadCards: Move<GameState> = ({ G, ctx, playerID, chat }: any, cards: Card[]) => {
   if(playerID !== '0') return INVALID_MOVE; // Only the host can bulk load cards
 
   // Bulk load batches of cards
@@ -112,10 +112,10 @@ const loadCards: Move<GameState> = ({ G, playerID, chat }: any, cards: Card[]) =
     loadBuffer.push(card);
   })
   G.cards.push(...loadBuffer);
-  chat.send({ type: 'event', text: `${cards.length} card(s) loaded into the deck` });
+  if (ctx.numPlayers > 1) chat.send({ type: 'event', text: `${cards.length} card(s) loaded into the deck` });
 }
 
-const shuffleCards: Move<GameState> = ({ G, playerID, chat }: any) => {
+const shuffleCards: Move<GameState> = ({ G, ctx, playerID, chat }: any) => {
   if(playerID !== '0') return INVALID_MOVE; // Only the host can reset the game
 
   // Return all cards to the deck, except those in the box
@@ -125,11 +125,12 @@ const shuffleCards: Move<GameState> = ({ G, playerID, chat }: any) => {
       card.timestamp = undefined;
     }
   });
-  chat.send({ type: 'event', text: `Player ${playerID} shuffled the deck` });
+  if (ctx.numPlayers > 1) chat.send({ type: 'event', text: `Player ${playerID} shuffled the deck` });
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const postMessage: Move<GameState> = ({ playerID, chat }: any, text: string, playerName?: string) => {
+const postMessage: Move<GameState> = ({ ctx, playerID, chat }: any, text: string, playerName?: string) => {
+  if (ctx.numPlayers <= 1) return INVALID_MOVE;
   if (!text || text.length > 500) return INVALID_MOVE;
   chat.send({ type: 'chat', playerID, playerName, text: text.trim() });
 }

--- a/core/src/Game.ts
+++ b/core/src/Game.ts
@@ -4,6 +4,7 @@ import { PluginPlayer } from 'boardgame.io/plugins';
 import { Card, getCardById, getCardsByLocation } from './Cards';
 import { presetDecks } from "./lib/constants";
 import { PluginChat } from "./lib/plugin-chat";
+import { PluginGameLog } from "./lib/plugin-gamelog";
 
 // Game State
 export interface GameState {
@@ -11,7 +12,7 @@ export interface GameState {
 }
 
 // Moves
-const pickupCard: Move<GameState> = ({ G, ctx, random, playerID, chat }: any) => {
+const pickupCard: Move<GameState> = ({ G, ctx, random, playerID, gamelog, chat }: any) => {
   const deck = getCardsByLocation(G.cards, "deck");
   if (deck.length === 0) {
     // Reshuffle Pile and Discard into Deck
@@ -41,15 +42,17 @@ const pickupCard: Move<GameState> = ({ G, ctx, random, playerID, chat }: any) =>
     card.owner = playerID;
     card.timestamp = Number(Date.now());
     card.location = "hand";
-    if (ctx.numPlayers > 1) chat.send({ type: 'event', playerID, text: `picked up a card` });
+    if (ctx.numPlayers > 1) {
+      gamelog.record({ move: 'pickupCard', playerID });
+      chat.syncFromLog(gamelog.entries());
+    }
   }
 }
 
-const moveCard: Move<GameState> = ({ G, ctx, playerID, chat }: any, id, target, owner) => {
+const moveCard: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, id, target, owner) => {
   const selectedCard = getCardById(G.cards, id);
   if (selectedCard) {
     const sourceLocation = selectedCard.location;
-    const sourceOwner = selectedCard.owner;
     if (['pile', 'discard', 'deck'].includes(target)) {
       selectedCard.location = target;
       selectedCard.owner = undefined;
@@ -67,32 +70,18 @@ const moveCard: Move<GameState> = ({ G, ctx, playerID, chat }: any, id, target, 
     }
     if (ctx.numPlayers > 1) {
       const publicLocations = ['pile', 'table'];
-      const sourcePublic = publicLocations.includes(sourceLocation);
-      const destPublic = publicLocations.includes(target);
-      const showTitle = sourcePublic || destPublic;
-      const title = showTitle ? `"${selectedCard.content.title.slice(0, 30)}"` : '';
+      const showTitle = publicLocations.includes(sourceLocation) || publicLocations.includes(target);
+      const cardTitle = showTitle ? selectedCard.content.title.slice(0, 30) : undefined;
       const recipientID = owner && owner !== playerID ? owner : undefined;
-
-      let text: string;
-      if (recipientID && target === 'hand') {
-        text = title ? `sent to {recipient}: ${title}` : `sent a card to {recipient}`;
-      } else if (recipientID) {
-        text = title ? `→ {recipient}'s ${target}: ${title}` : `→ {recipient}'s ${target}`;
-      } else if (target === 'pile') {
-        // playing to pile — omit destination
-        text = title ? `→ ${title}` : `→ pile`;
-      } else {
-        text = title ? `→ ${target}: ${title}` : `→ ${target}`;
-      }
-
-      chat.send({ type: 'event', playerID, targetPlayerID: recipientID, text });
+      gamelog.record({ move: 'moveCard', playerID, cardID: selectedCard.id, cardTitle, target, targetPlayerID: recipientID });
+      chat.syncFromLog(gamelog.entries());
     }
   } else {
     return INVALID_MOVE;
   }
 }
 
-const claimCard: Move<GameState> = ({ G, ctx, playerID, chat }: any, id) => {
+const claimCard: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, id) => {
   const selectedCard = getCardById(G.cards, id);
   if (selectedCard) {
     if (selectedCard.location == 'pile') {
@@ -100,7 +89,10 @@ const claimCard: Move<GameState> = ({ G, ctx, playerID, chat }: any, id) => {
       selectedCard.owner = playerID;
       selectedCard.timestamp = Number(Date.now());
       selectedCard.location = 'hand';
-      if (ctx.numPlayers > 1) chat.send({ type: 'event', playerID, text: `← "${selectedCard.content.title.slice(0, 30)}"` });
+      if (ctx.numPlayers > 1) {
+        gamelog.record({ move: 'claimCard', playerID, cardID: selectedCard.id, cardTitle: selectedCard.content.title.slice(0, 30) });
+        chat.syncFromLog(gamelog.entries());
+      }
     } else {
       return INVALID_MOVE;
     }
@@ -120,13 +112,16 @@ const likeCard: Move<GameState> = ({ G }, id) => {
   }
 }
 
-const submitCard: Move<GameState> = ({ G, ctx, chat }: any, card: Card, playerName?: string) => {
+const submitCard: Move<GameState> = ({ G, ctx, gamelog, chat }: any, card: Card, playerName?: string) => {
   card.id = G.cards.length + 1; // Commit ID sequentially to GameState
   G.cards.push(card);
-  if (ctx.numPlayers > 1) chat.send({ type: 'event', text: `${playerName || 'Someone'} made a card` });
+  if (ctx.numPlayers > 1) {
+    gamelog.record({ move: 'submitCard', playerID: card.owner || '', playerName, cardID: card.id, cardTitle: card.content.title.slice(0, 30) });
+    chat.syncFromLog(gamelog.entries());
+  }
 }
 
-const loadCards: Move<GameState> = ({ G, ctx, playerID, chat }: any, cards: Card[]) => {
+const loadCards: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, cards: Card[]) => {
   if(playerID !== '0') return INVALID_MOVE; // Only the host can bulk load cards
 
   // Bulk load batches of cards
@@ -139,11 +134,12 @@ const loadCards: Move<GameState> = ({ G, ctx, playerID, chat }: any, cards: Card
   G.cards.push(...loadBuffer);
   if (ctx.numPlayers > 1) {
     const deckSize = G.cards.filter((c: Card) => c.location === 'deck').length;
-    chat.send({ type: 'event', text: `${cards.length} ${cards.length === 1 ? 'card' : 'cards'} loaded — ${deckSize} in deck` });
+    gamelog.record({ move: 'loadCards', playerID, count: cards.length, delta: deckSize });
+    chat.syncFromLog(gamelog.entries());
   }
 }
 
-const shuffleCards: Move<GameState> = ({ G, ctx, playerID, chat }: any) => {
+const shuffleCards: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any) => {
   if(playerID !== '0') return INVALID_MOVE; // Only the host can reset the game
 
   // Return all cards to the deck, except those in the box
@@ -155,28 +151,28 @@ const shuffleCards: Move<GameState> = ({ G, ctx, playerID, chat }: any) => {
   });
   if (ctx.numPlayers > 1) {
     const deckSize = G.cards.filter((c: Card) => c.location !== 'box').length;
-    chat.send({ type: 'event', playerID, text: `shuffled — ${deckSize} in deck` });
+    gamelog.record({ move: 'shuffleCards', playerID, count: deckSize });
+    chat.syncFromLog(gamelog.entries());
   }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const postMessage: Move<GameState> = ({ ctx, playerID, chat }: any, text: string, playerName?: string) => {
+const postMessage: Move<GameState> = ({ ctx, playerID, gamelog, chat }: any, text: string, playerName?: string) => {
   if (ctx.numPlayers <= 1) return INVALID_MOVE;
   if (!text || text.length > 500) return INVALID_MOVE;
-  chat.send({ type: 'chat', playerID, playerName, text: text.trim() });
+  gamelog.record({ move: 'postMessage', playerID, playerName, text: text.trim() });
+  chat.syncFromLog(gamelog.entries());
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const setScore: Move<GameState> = ({ ctx, player, chat }: any, targetPlayerID: string, value: number, setterName?: string, targetName?: string) => {
+const setScore: Move<GameState> = ({ ctx, player, gamelog, chat }: any, targetPlayerID: string, value: number, setterName?: string, targetName?: string) => {
   if (player?.state && targetPlayerID in player.state) {
     const prev = player.state[targetPlayerID]?.score ?? 0;
     player.state[targetPlayerID] = { score: value };
     if (ctx.numPlayers > 1) {
       const delta = value - prev;
-      const deltaStr = delta >= 0 ? `+${delta}` : `${delta}`;
-      const who = targetName || `Player ${targetPlayerID}`;
-      const by = setterName && setterName !== targetName ? ` (by ${setterName})` : '';
-      chat.send({ type: 'event', text: `${deltaStr} pts for ${who}${by}` });
+      gamelog.record({ move: 'setScore', playerID: targetPlayerID, targetPlayerID, targetPlayerName: targetName, setterName, delta });
+      chat.syncFromLog(gamelog.entries());
     }
   } else {
     return INVALID_MOVE;
@@ -252,6 +248,7 @@ export const BlankWhiteCards: Game<GameState> = {
 
   plugins: [
     PluginPlayer({ setup: () => ({ score: 0 as number }) }),
+    PluginGameLog(),
     PluginChat(),
   ],
 

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -1,5 +1,7 @@
 export { BlankWhiteCards } from './Game';
 export type { GameState } from './Game';
 export { getCardById, getCardsByLocation, getCardsByOwner, getAdjacentCard } from './Cards';
-export type { Card } from './Cards';
+export type { Card, Message } from './Cards';
 export { presetDecks, startDeckPolling } from './lib/constants';
+export { PluginChat } from './lib/plugin-chat';
+export type { ChatPlugin, ChatAPI } from './lib/plugin-chat';

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -5,3 +5,5 @@ export type { Card, Message } from './Cards';
 export { presetDecks, startDeckPolling } from './lib/constants';
 export { PluginChat } from './lib/plugin-chat';
 export type { ChatPlugin, ChatAPI } from './lib/plugin-chat';
+export { PluginGameLog } from './lib/plugin-gamelog';
+export type { GameLogPlugin, GameLogAPI, GameLogEntry, GameLogMove } from './lib/plugin-gamelog';

--- a/core/src/lib/plugin-chat.ts
+++ b/core/src/lib/plugin-chat.ts
@@ -21,9 +21,13 @@ const MAX_MESSAGES = 200;
 
 export const PluginChat = (): Plugin<ChatAPI, ChatData> => ({
   name: 'chat',
-  setup: () => ({ messages: [], lastLogId: 0 }),
+  setup: () => ({
+    messages: [{ id: 0, type: 'event' as const, text: 'Welcome to Blank White Cards', timestamp: Date.now() }],
+    lastLogId: 0,
+  }),
   api: ({ data }) => ({
     syncFromLog: (entries: GameLogEntry[]) => {
+      if (!data?.messages) return;
       const newEntries = entries.filter(e => e.id > data.lastLogId);
       for (const entry of newEntries) {
         const msg = logEntryToMessage(entry);

--- a/core/src/lib/plugin-chat.ts
+++ b/core/src/lib/plugin-chat.ts
@@ -22,7 +22,7 @@ const MAX_MESSAGES = 200;
 export const PluginChat = (): Plugin<ChatAPI, ChatData> => ({
   name: 'chat',
   setup: () => ({
-    messages: [{ id: 0, type: 'event' as const, text: 'Welcome to Blank White Cards', timestamp: Date.now() }],
+    messages: [{ id: -1, type: 'event' as const, text: 'Welcome to Blank White Cards', timestamp: Date.now() }],
     lastLogId: 0,
   }),
   api: ({ data }) => ({

--- a/core/src/lib/plugin-chat.ts
+++ b/core/src/lib/plugin-chat.ts
@@ -1,12 +1,15 @@
 import type { Plugin } from 'boardgame.io';
 import type { Message } from '../Cards';
+import type { GameLogEntry } from './plugin-gamelog';
+import { logEntryToMessage } from './plugin-gamelog';
 
 interface ChatData {
   messages: Message[];
+  lastLogId: number; // tracks which log entries have been converted
 }
 
 export interface ChatAPI {
-  send(msg: Omit<Message, 'id' | 'timestamp'>): void;
+  syncFromLog(entries: GameLogEntry[]): void;
   getMessages(): Message[];
 }
 
@@ -18,13 +21,20 @@ const MAX_MESSAGES = 200;
 
 export const PluginChat = (): Plugin<ChatAPI, ChatData> => ({
   name: 'chat',
-  setup: () => ({ messages: [] }),
+  setup: () => ({ messages: [], lastLogId: 0 }),
   api: ({ data }) => ({
-    send: (msg) => {
-      data.messages.push({ ...msg, id: data.messages.length + 1, timestamp: Date.now() });
-      if (data.messages.length > MAX_MESSAGES) data.messages.shift();
+    syncFromLog: (entries: GameLogEntry[]) => {
+      const newEntries = entries.filter(e => e.id > data.lastLogId);
+      for (const entry of newEntries) {
+        const msg = logEntryToMessage(entry);
+        if (msg) {
+          data.messages.push(msg);
+          if (data.messages.length > MAX_MESSAGES) data.messages.shift();
+        }
+        data.lastLogId = entry.id;
+      }
     },
     getMessages: () => data.messages,
   }),
-  flush: ({ api }) => ({ messages: api.getMessages() }),
+  flush: ({ api, data }) => ({ messages: api.getMessages(), lastLogId: data.lastLogId }),
 });

--- a/core/src/lib/plugin-chat.ts
+++ b/core/src/lib/plugin-chat.ts
@@ -1,0 +1,30 @@
+import type { Plugin } from 'boardgame.io';
+import type { Message } from '../Cards';
+
+interface ChatData {
+  messages: Message[];
+}
+
+export interface ChatAPI {
+  send(msg: Omit<Message, 'id' | 'timestamp'>): void;
+  getMessages(): Message[];
+}
+
+export interface ChatPlugin extends Record<string, unknown> {
+  chat: ChatAPI;
+}
+
+const MAX_MESSAGES = 200;
+
+export const PluginChat = (): Plugin<ChatAPI, ChatData> => ({
+  name: 'chat',
+  setup: () => ({ messages: [] }),
+  api: ({ data }) => ({
+    send: (msg) => {
+      data.messages.push({ ...msg, id: data.messages.length + 1, timestamp: Date.now() });
+      if (data.messages.length > MAX_MESSAGES) data.messages.shift();
+    },
+    getMessages: () => data.messages,
+  }),
+  flush: ({ api }) => ({ messages: api.getMessages() }),
+});

--- a/core/src/lib/plugin-gamelog.ts
+++ b/core/src/lib/plugin-gamelog.ts
@@ -1,0 +1,113 @@
+import type { Plugin } from 'boardgame.io';
+import type { Message } from '../Cards';
+
+export type GameLogMove =
+  | 'pickupCard'
+  | 'moveCard'
+  | 'claimCard'
+  | 'submitCard'
+  | 'shuffleCards'
+  | 'loadCards'
+  | 'setScore'
+  | 'postMessage';
+
+export interface GameLogEntry {
+  id: number;
+  timestamp: number;
+  move: GameLogMove;
+  playerID: string;
+  playerName?: string; // display name of the actor (where available from client)
+  cardID?: number;
+  cardTitle?: string;
+  target?: string;
+  targetPlayerID?: string;
+  targetPlayerName?: string;
+  count?: number;   // for loadCards (cards added), shuffleCards (deck size after)
+  delta?: number;   // for setScore
+  setterID?: string; // for setScore (who set the score)
+  setterName?: string;
+  text?: string;    // for postMessage chat text
+}
+
+interface GameLogData {
+  entries: GameLogEntry[];
+}
+
+export interface GameLogAPI {
+  record(entry: Omit<GameLogEntry, 'id' | 'timestamp'>): void;
+  entries(): GameLogEntry[];
+}
+
+export interface GameLogPlugin {
+  gamelog: GameLogAPI;
+}
+
+const MAX_ENTRIES = 500;
+
+/** Convert a game log entry to a chat Message for display. Returns null for entries that shouldn't appear in chat. */
+export function logEntryToMessage(entry: GameLogEntry): Message | null {
+  const base = { id: entry.id, timestamp: entry.timestamp, playerID: entry.playerID };
+
+  switch (entry.move) {
+    case 'pickupCard':
+      return { ...base, type: 'event', text: 'picked up a card' };
+
+    case 'claimCard':
+      return { ...base, type: 'event', text: `← "${entry.cardTitle}"` };
+
+    case 'moveCard': {
+      const title = entry.cardTitle ? `"${entry.cardTitle}"` : '';
+      const recipientID = entry.targetPlayerID;
+
+      let text: string;
+      if (recipientID && entry.target === 'hand') {
+        text = title ? `sent to {recipient}: ${title}` : `sent a card to {recipient}`;
+      } else if (recipientID) {
+        text = title ? `→ {recipient}'s ${entry.target}: ${title}` : `→ {recipient}'s ${entry.target}`;
+      } else if (entry.target === 'pile') {
+        text = title ? `→ ${title}` : `→ pile`;
+      } else {
+        text = title ? `→ ${entry.target}: ${title}` : `→ ${entry.target}`;
+      }
+
+      return { ...base, type: 'event', targetPlayerID: recipientID, text };
+    }
+
+    case 'submitCard':
+      return { ...base, type: 'event', playerName: entry.playerName, text: 'made a card' };
+
+    case 'shuffleCards':
+      return { ...base, type: 'event', text: `shuffled — ${entry.count} in deck` };
+
+    case 'loadCards':
+      return { id: entry.id, timestamp: entry.timestamp, type: 'event', text: `${entry.count} ${entry.count === 1 ? 'card' : 'cards'} loaded — ${entry.delta} in deck` };
+
+    case 'setScore': {
+      const deltaStr = (entry.delta ?? 0) >= 0 ? `+${entry.delta}` : `${entry.delta}`;
+      const target = entry.targetPlayerName || `Player ${entry.targetPlayerID}`;
+      const by = entry.setterName && entry.setterName !== target ? ` (by ${entry.setterName})` : '';
+      return { ...base, type: 'event', targetPlayerID: entry.targetPlayerID, text: `${deltaStr} pts for ${target}${by}` };
+    }
+
+    case 'postMessage':
+      return { ...base, type: 'chat', playerName: entry.playerName, text: entry.text || '' };
+
+    default:
+      return null;
+  }
+}
+
+export const PluginGameLog = (): Plugin<GameLogAPI, GameLogData> => ({
+  name: 'gamelog',
+  setup: () => ({ entries: [] }),
+  api: ({ data }) => ({
+    record: (entry) => {
+      data.entries.push({ ...entry, id: data.entries.length + 1, timestamp: Date.now() });
+      if (data.entries.length > MAX_ENTRIES) data.entries.shift();
+    },
+    entries: () => data.entries,
+  }),
+  flush: ({ api }) => ({ entries: api.entries() }),
+  // Server-side only — hide from clients
+  playerView: () => undefined,
+});

--- a/core/src/lib/plugin-gamelog.ts
+++ b/core/src/lib/plugin-gamelog.ts
@@ -102,10 +102,11 @@ export const PluginGameLog = (): Plugin<GameLogAPI, GameLogData> => ({
   setup: () => ({ entries: [] }),
   api: ({ data }) => ({
     record: (entry) => {
+      if (!data?.entries) return;
       data.entries.push({ ...entry, id: data.entries.length + 1, timestamp: Date.now() });
       if (data.entries.length > MAX_ENTRIES) data.entries.shift();
     },
-    entries: () => data.entries,
+    entries: () => data?.entries ?? [],
   }),
   flush: ({ api }) => ({ entries: api.entries() }),
   // Server-side only — hide from clients

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,37 @@
+# System Events
+
+System events are automatically appended to the chat log when certain game moves occur in multiplayer sessions (`ctx.numPlayers > 1`). They appear in the console as italic grey text with the player name prepended.
+
+Player names are resolved client-side from `matchData` using `playerID`. Events without a `playerID` (e.g. `loadCards`) show text only.
+
+## Current events
+
+| Move | Message | Notes |
+|------|---------|-------|
+| `pickupCard` | `{name}` picked up a card | |
+| `claimCard` | `{name}` ← `"{title}"` | Title always shown (pile is public) |
+| `moveCard` | `{name}` → `{dest}`: `"{title}"` | See below |
+| `submitCard` | `{name}` made a card | Name passed from client |
+| `shuffleCards` | `{name}` shuffled — `{n}` in deck | |
+| `loadCards` | `{n}` card/cards loaded — `{total}` in deck | No player attribution |
+| `setScore` | `{delta}` pts for `{target}` *(by `{setter}` if different)* | Names passed from client |
+
+## moveCard title visibility
+
+Title is shown if **either the source or destination** is a public location. Only `pile` and `table` are public — `discard`, `hand`, and `deck` are private.
+
+Note: all combinations are valid server-side. The UI restricts which moves are exposed, but the MCP or direct API calls can trigger any combination.
+
+| → dest ↓ src | pile | table | hand | discard | deck |
+|--------------|:----:|:-----:|:----:|:-------:|:----:|
+| **pile**     | ✓    | ✓     | ✓    | ✓       | ✓    |
+| **table**    | ✓    | ✓     | ✓    | ✓       | ✓    |
+| **hand**     | ✓    | ✓     | ✗    | ✗       | ✗    |
+| **discard**  | ✓    | ✓     | ✗    | ✗       | ✗    |
+| **deck**     | ✓    | ✓     | ✗    | ✗       | ✗    |
+
+## Not currently tracked
+
+| Move | Notes |
+|------|-------|
+| `pickupCard` deduplication | Multiple pickups show separate events |

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1,0 +1,23 @@
+# UI Layer Stack (z-index)
+
+wired-dialog renders at `z-index: 100` (via `--wired-dialog-z-index`). Anything that must appear above it needs `> 100`.
+
+| z-index | Element | File |
+|---------|---------|------|
+| 10 | Pile like count badge (absolute, inside pile card) | CommonSpace |
+| 10 | Focus prev/next browse icons (absolute, inside focus overlay) | Focus |
+| 20 | QR code share popup | CommonSpace |
+| 20 | Share button/card | CommonSpace |
+| 20 | DeckEditor toolbar item | DeckEditor |
+| 20 | CardEditor toolbar | CardEditor |
+| 30 | Finalise panel (card create overlay) | Finalise |
+| 30 | Toolbar (bottom fixed action bar) | ActionSpace |
+| 40 | Console toggle + panel | Console |
+| 40 | Score editing overlay | CommonSpace |
+| 50 | Header (top fixed bar) | CommonSpace |
+| 50 | Sketch mode draw tools row | ActionSpace |
+| 50 | Gallery bottom bar | Gallery |
+| 50 | DeckEditor toolbars | DeckEditor |
+| 60 | DeckEditor modals / image picker | DeckEditor |
+| 60 | CardEditor modal | CardEditor |
+| 110 | Focus overlay (fullscreen card focus, beats wired-dialog) | Focus |

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -14,7 +14,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { BlankWhiteCards } from '@mcteamster/white-core';
 import { version } from './package.json';
-import type { Card } from '@mcteamster/white-core';
+import type { Card, Message } from '@mcteamster/white-core';
 
 // Temporary store for out-of-band image uploads: uploadId -> processed data URI
 const imageUploadStore = new Map<string, string>();
@@ -81,11 +81,12 @@ function getScores(state: Record<string, unknown>, playOrder: string[]): Record<
   return Object.fromEntries(playOrder.map(id => [id, players?.[id]?.score ?? 0]));
 }
 
-function formatState(state: { G: { cards: Card[] }; ctx: Record<string, unknown> }, playerID: string) {
+function formatState(state: { G: { cards: Card[] }; ctx: Record<string, unknown>; plugins?: Record<string, unknown> }, playerID: string) {
   const { G, ctx } = state;
   const cards = G.cards;
   const playOrder = ctx.playOrder as string[];
   const scores = getScores(state as Record<string, unknown>, playOrder);
+  const allMessages = (state as any)?.plugins?.chat?.data?.messages as Message[] | undefined;
   return {
     my_hand: cards.filter(c => c.location === 'hand' && c.owner === playerID).map(stripImage),
     my_table: cards.filter(c => c.location === 'table' && c.owner === playerID).map(stripImage),
@@ -96,6 +97,7 @@ function formatState(state: { G: { cards: Card[] }; ctx: Record<string, unknown>
     num_players: ctx.numPlayers,
     play_order: playOrder,
     scores,
+    recent_messages: allMessages ? allMessages.slice(-10) : [],
   };
 }
 
@@ -129,10 +131,11 @@ interface CardSnapshot {
   owner?: string;
   previousOwner?: string;
   likes?: number;
+  messageCount?: number;
 }
 
 interface CardEvent {
-  type: 'card_submitted' | 'card_claimed' | 'card_moved' | 'card_liked' | 'shuffled';
+  type: 'card_submitted' | 'card_claimed' | 'card_moved' | 'card_liked' | 'shuffled' | 'message';
   card?: ReturnType<typeof stripImage>;
   cardID?: number;
   from?: string;
@@ -140,6 +143,7 @@ interface CardEvent {
   toOwner?: string;
   byPlayer?: string;
   likes?: number;
+  message?: Message;
 }
 
 function snapshotCards(cards: Card[]): CardSnapshot[] {
@@ -188,10 +192,12 @@ function diffCards(prev: CardSnapshot[], next: Card[]): CardEvent[] {
 
 function eventMatchesFlags(
   event: CardEvent,
-  flags: { pile?: boolean; hand?: boolean; table?: boolean },
+  flags: { pile?: boolean; hand?: boolean; table?: boolean; messages?: boolean },
   playerID: string,
 ): boolean {
-  if (!flags.pile && !flags.hand && !flags.table) return true;
+  if (!flags.pile && !flags.hand && !flags.table && !flags.messages) return true;
+
+  if (flags.messages && event.type === 'message') return true;
 
   if (flags.pile) {
     if (event.type === 'card_submitted') return true;
@@ -214,7 +220,7 @@ function eventMatchesFlags(
 function watchForChange(
   client: ReturnType<typeof Client>,
   playerID: string,
-  flags: { pile?: boolean; hand?: boolean; table?: boolean },
+  flags: { pile?: boolean; hand?: boolean; table?: boolean; messages?: boolean },
   timeoutMs: number,
 ): Promise<{ changed: boolean; events: CardEvent[]; state?: unknown }> {
   return new Promise(resolve => {
@@ -225,6 +231,7 @@ function watchForChange(
     }
 
     const snapshot = snapshotCards(currentState.G.cards);
+    const snapshotMessageCount = ((currentState as any)?.plugins?.chat?.data?.messages as Message[] | undefined)?.length ?? 0;
     let settled = false;
     let unsub: (() => void) | undefined;
 
@@ -241,8 +248,14 @@ function watchForChange(
     unsub = client.subscribe((state: unknown) => {
       if (!state || !(state as { G?: { cards?: Card[] } }).G?.cards) return;
       const cards = (state as { G: { cards: Card[] } }).G.cards;
-      const events = diffCards(snapshot, cards);
-      const relevant = events.filter(e => eventMatchesFlags(e, flags, playerID));
+      const cardEvents = diffCards(snapshot, cards);
+
+      const allMessages = ((state as any)?.plugins?.chat?.data?.messages as Message[] | undefined) ?? [];
+      const newMessages = allMessages.slice(snapshotMessageCount);
+      const messageEvents: CardEvent[] = newMessages.map(m => ({ type: 'message' as const, message: m }));
+
+      const allEvents = [...cardEvents, ...messageEvents];
+      const relevant = allEvents.filter(e => eventMatchesFlags(e, flags, playerID));
       if (relevant.length > 0) {
         // Delay before returning so other players have time to digest the move
         setTimeout(() => done({ changed: true, events: relevant, state }), MIN_REACT_SECONDS * 1000);
@@ -291,6 +304,14 @@ Players have scores tracked per-match. Scores are set manually — they are not 
 - 'get_leaderboard' — scores sorted by rank
 - 'set_score' — set any player's score to a new value
 - 'get_play_hint' — get a suggested action based on your score position relative to others
+
+## Chat
+
+A shared message feed is visible to all players. It contains both player chat messages and system events (cards submitted, shuffles, score changes, etc.).
+
+- 'send_message' — post a chat message as the current player (multiplayer only)
+- 'get_messages' — retrieve the full feed, or pass 'since' (timestamp ms) to fetch only new messages
+- 'watch' with 'messages: true' — fire when any new message arrives
 
 ## Available prompts
 
@@ -540,7 +561,7 @@ mcp.registerTool(
     const nextState = waitForMove(client);
     client.moves.pickupCard();
     const state = await nextState;
-    return text(formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown> }, playerID));
+    return text(formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown>; plugins?: Record<string, unknown> }, playerID));
   }
 );
 
@@ -561,7 +582,7 @@ mcp.registerTool(
     const nextState = waitForMove(client);
     client.moves.moveCard(cardID, target, toOwner);
     const state = await nextState;
-    return text(formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown> }, playerID));
+    return text(formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown>; plugins?: Record<string, unknown> }, playerID));
   }
 );
 
@@ -580,7 +601,7 @@ mcp.registerTool(
     const nextState = waitForMove(client);
     client.moves.claimCard(cardID);
     const state = await nextState;
-    return text(formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown> }, playerID));
+    return text(formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown>; plugins?: Record<string, unknown> }, playerID));
   }
 );
 
@@ -640,7 +661,7 @@ mcp.registerTool(
     const nextState = waitForMove(client);
     client.moves.submitCard(card);
     const state = await nextState;
-    return text(formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown> }, playerID));
+    return text(formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown>; plugins?: Record<string, unknown> }, playerID));
   }
 );
 
@@ -659,7 +680,7 @@ mcp.registerTool(
     const nextState = waitForMove(client);
     client.moves.likeCard(cardID);
     const state = await nextState;
-    return text(formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown> }, playerID));
+    return text(formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown>; plugins?: Record<string, unknown> }, playerID));
   }
 );
 
@@ -754,6 +775,45 @@ mcp.registerTool(
 );
 
 mcp.registerTool(
+  'get_messages',
+  {
+    description: 'Retrieve the message feed (chat + system events), optionally filtered to only messages newer than a given timestamp',
+    inputSchema: {
+      matchID: z.string().describe('Room code'),
+      playerID: z.string().describe('Your player ID'),
+      since: z.number().optional().describe('Unix timestamp ms — return only messages newer than this'),
+    },
+  },
+  async ({ matchID, playerID, since }) => {
+    const { client } = requireSession(matchID, playerID);
+    const state = client.store.getState();
+    if (!state?.G) throw new Error('No state available yet');
+    const messages = ((state as any)?.plugins?.chat?.data?.messages as Message[] | undefined) ?? [];
+    const filtered = since != null ? messages.filter(m => m.timestamp > since) : messages;
+    return text({ count: filtered.length, messages: filtered });
+  }
+);
+
+mcp.registerTool(
+  'send_message',
+  {
+    description: 'Post a chat message to the game console as the current player',
+    inputSchema: {
+      matchID: z.string().describe('Room code'),
+      playerID: z.string().describe('Your player ID'),
+      text: z.string().describe('Message to send'),
+    },
+  },
+  async ({ matchID, playerID, text: messageText }) => {
+    const { client } = requireSession(matchID, playerID);
+    const nextState = waitForMove(client);
+    client.moves.postMessage(messageText, playerID);
+    const state = await nextState;
+    return text(formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown>; plugins?: Record<string, unknown> }, playerID));
+  }
+);
+
+mcp.registerTool(
   'set_score',
   {
     description: 'Set the score for a player',
@@ -769,7 +829,7 @@ mcp.registerTool(
     const nextState = waitForMove(client);
     client.moves.setScore(targetPlayerID, score);
     const state = await nextState;
-    return text(formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown> }, playerID));
+    return text(formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown>; plugins?: Record<string, unknown> }, playerID));
   }
 );
 
@@ -787,7 +847,7 @@ mcp.registerTool(
     const nextState = waitForMove(client);
     client.moves.shuffleCards();
     const state = await nextState;
-    return text(formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown> }, playerID));
+    return text(formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown>; plugins?: Record<string, unknown> }, playerID));
   }
 );
 
@@ -835,7 +895,7 @@ mcp.registerTool(
     const nextState = waitForMove(client);
     client.moves.loadCards(cardObjects);
     const state = await nextState;
-    return text(formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown> }, playerID));
+    return text(formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown>; plugins?: Record<string, unknown> }, playerID));
   }
 );
 
@@ -849,13 +909,14 @@ mcp.registerTool(
       pile: z.boolean().optional().describe('Fire when the pile changes (cards submitted, claimed, or moved to/from pile)'),
       hand: z.boolean().optional().describe('Fire when your hand changes (card received or removed)'),
       table: z.boolean().optional().describe('Fire when any table changes occur'),
+      messages: z.boolean().optional().describe('Fire when a new chat or system event message appears'),
       timeout_seconds: z.number().int().min(5).max(300).optional().describe(`How long to wait before giving up (default ${MAX_WATCH_SECONDS}s, set by MCP_MAX_WATCH_SECONDS)`),
     },
   },
-  async ({ matchID, playerID, pile, hand, table, timeout_seconds }) => {
+  async ({ matchID, playerID, pile, hand, table, messages, timeout_seconds }) => {
     const session = requireSession(matchID, playerID);
     const { client } = session;
-    const flags = { pile: pile ?? false, hand: hand ?? false, table: table ?? false };
+    const flags = { pile: pile ?? false, hand: hand ?? false, table: table ?? false, messages: messages ?? false };
     const { changed, events, state } = await watchForChange(client, playerID, flags, (timeout_seconds ?? MAX_WATCH_SECONDS) * 1000);
     const watch = ++session.watchCount;
     if (!changed) return text({ watch, changed: false, message: 'No activity — your turn to act. Pick up a card, submit something, or play from your hand. Then call watch again.' });
@@ -863,7 +924,7 @@ mcp.registerTool(
       watch,
       changed: true,
       events,
-      state: formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown> }, playerID),
+      state: formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown>; plugins?: Record<string, unknown> }, playerID),
     });
   }
 );
@@ -928,8 +989,8 @@ After EVERY action → call 'watch'. After EVERY 'watch' response (fired or time
 
 ## Play loop
 
-1. Call 'watch' with 'pile: true' and 'hand: true'.
-2. **If 'watch' fires** — react: claim interesting cards, like good ones, write a response card. Reset your timeout count to 0.
+1. Call 'watch' with 'pile: true', 'hand: true', and 'messages: true'.
+2. **If 'watch' fires** — react: claim interesting cards, like good ones, write a response card, or reply to chat messages with 'send_message'. Reset your timeout count to 0.
 3. **If 'watch' times out** — increment your timeout count. If it has timed out twice in a row, take one action (pick up a card, submit something, play from hand) and reset the count to 0.
 4. GOTO 1. Always. Without exception.
 

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -65,6 +65,7 @@ interface Session {
   client: ReturnType<typeof Client>;
   credentials: string;
   watchCount: number;
+  playerName?: string;
 }
 
 // ── Session helpers (inside createMcpServer) ──────────────────────────────────
@@ -326,7 +327,7 @@ function sessionKey(matchID: string, playerID: string) {
   return `${matchID}:${playerID}`;
 }
 
-async function connectSession(matchID: string, playerID: string, credentials: string, server: string): Promise<Session> {
+async function connectSession(matchID: string, playerID: string, credentials: string, server: string, playerName?: string): Promise<Session> {
   const key = sessionKey(matchID, playerID);
   const existing = sessions.get(key);
   if (existing) existing.client.stop?.();
@@ -351,7 +352,7 @@ async function connectSession(matchID: string, playerID: string, credentials: st
     client.start();
   });
 
-  const session: Session = { client, credentials, watchCount: 0 };
+  const session: Session = { client, credentials, watchCount: 0, playerName };
   sessions.set(key, session);
   return session;
 }
@@ -436,7 +437,7 @@ mcp.registerTool(
       playerID: '0',
       playerName: player_name ?? 'Player 0',
     });
-    await connectSession(matchID, '0', playerCredentials, server);
+    await connectSession(matchID, '0', playerCredentials, server, player_name ?? 'Player 0');
     return text({ matchID, playerID: '0', credentials: playerCredentials, server, message: `Joined ${matchID} as player 0` });
   }
 );
@@ -459,7 +460,7 @@ mcp.registerTool(
       playerName: player_name ?? `Player ${playerID ?? '?'}`,
     });
     const id = assignedID ?? playerID!;
-    await connectSession(matchID, id, playerCredentials, server);
+    await connectSession(matchID, id, playerCredentials, server, player_name ?? `Player ${id}`);
     return text({ matchID, playerID: id, server, message: `Joined ${matchID} as player ${id}` });
   }
 );
@@ -805,9 +806,10 @@ mcp.registerTool(
     },
   },
   async ({ matchID, playerID, text: messageText }) => {
-    const { client } = requireSession(matchID, playerID);
+    const session = requireSession(matchID, playerID);
+    const { client } = session;
     const nextState = waitForMove(client);
-    client.moves.postMessage(messageText, playerID);
+    client.moves.postMessage(messageText, session.playerName);
     const state = await nextState;
     return text(formatState(state as { G: { cards: Card[] }; ctx: Record<string, unknown>; plugins?: Record<string, unknown> }, playerID));
   }

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@mcteamster/white-mcp",
-  "version": "2.3.6",
+  "version": "2.3.8",
   "main": "dist/index.js",
   "bin": "dist/index.js",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "start": "tsx index.ts",
     "serve": "MCP_HTTP_PORT=${MCP_HTTP_PORT:-8000} tsx index.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blankwhitecards",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blankwhitecards",
-      "version": "2.3.7",
+      "version": "2.3.8",
       "workspaces": [
         "core",
         "app",
@@ -21,7 +21,7 @@
     },
     "api": {
       "name": "@mcteamster/white-api",
-      "version": "2.3.3",
+      "version": "2.3.8",
       "dependencies": {
         "@aws-sdk/client-cloudfront": "^3.0.0",
         "@aws-sdk/client-s3": "^3.0.0",
@@ -48,7 +48,7 @@
     },
     "app": {
       "name": "@mcteamster/white-app",
-      "version": "2.3.3",
+      "version": "2.3.8",
       "dependencies": {
         "@discord/embedded-app-sdk": "^2.0.0",
         "@emotion/styled": "^11.14.0",
@@ -79,14 +79,14 @@
     },
     "core": {
       "name": "@mcteamster/white-core",
-      "version": "2.3.3",
+      "version": "2.3.8",
       "dependencies": {
         "boardgame.io": "^0.50.2"
       }
     },
     "mcp": {
       "name": "@mcteamster/white-mcp",
-      "version": "2.3.3",
+      "version": "2.3.8",
       "bin": {
         "white-mcp": "dist/index.js"
       },
@@ -10833,7 +10833,7 @@
     },
     "server": {
       "name": "@mcteamster/white-server",
-      "version": "2.3.3",
+      "version": "2.3.8",
       "dependencies": {
         "@mcteamster/white-core": "*",
         "boardgame.io": "^0.50.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blankwhitecards",
-  "version": "2.3.3",
+  "version": "2.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blankwhitecards",
-      "version": "2.3.3",
+      "version": "2.3.7",
       "workspaces": [
         "core",
         "app",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blankwhitecards",
   "private": true,
-  "version": "2.3.6",
+  "version": "2.3.7",
   "workspaces": [
     "core",
     "app",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blankwhitecards",
   "private": true,
-  "version": "2.3.7",
+  "version": "2.3.8",
   "workspaces": [
     "core",
     "app",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcteamster/white-server",
   "private": true,
-  "version": "2.3.6",
+  "version": "2.3.8",
   "scripts": {
     "start": "node --env-file=.env.production --import tsx ./index.ts",
     "dev": "node --env-file=.env.development --import tsx ./index.ts"


### PR DESCRIPTION
Implements the full in-game chat and game console feature across core, app, and MCP.

## Tickets
- **BWC-11** Chat log / game console
- **BWC-36** PluginGameLog (structured game event log)
- **BWC-12** MCP chat tools

---

## Core (`core/`)

**PluginGameLog** (BWC-36)
- New `PluginGameLog` boardgame.io plugin — stores structured `GameLogEntry[]` server-side only (`playerView: () => undefined`)
- All moves call `gamelog.record()` instead of formatting strings directly
- `logEntryToMessage()` centralises all display formatting
- System events: `pickupCard`, `moveCard`, `claimCard`, `submitCard`, `shuffleCards`, `loadCards`, `setScore`, `postMessage`
- `moveCard` title visibility rule: show card title only if source or destination is `pile` or `table`
- System events suppressed in single player (`ctx.numPlayers <= 1`)

**PluginChat** (BWC-11)
- Derives `Message[]` from game log entries via `syncFromLog()`
- Seeded with welcome message (`id: -1` to avoid collision with log-derived IDs)
- Capped at 200 messages
- `Message` interface: `id, type, playerID?, playerName?, targetPlayerID?, text, timestamp`
- `postMessage` move for player chat (multiplayer only)

## App (`app/`)

**Console component** (BWC-11)
- Fixed notch at top-left below header
- Shows latest message preview when closed (italic+grey for events, normal for chat); unread count badge
- Open panel: always 70vh height, messages anchor to bottom (`flex-end`)
- Event filter toggle (floating top-right of panel, eye icon)
- Chat disclaimer below input: "Messages are visible to all players. Do not share personal information."
- Enter key sends; `scrollbarWidth: none`
- Chat/players tray mutually exclusive on screens < 600px wide

**Other**
- Z-index normalised across all components (10→110, documented in `docs/layers.md`)
- `chat` icon added to `Icons.tsx`

## MCP (`mcp/`)

**Chat tools** (BWC-12)
- `send_message` — posts chat via `postMessage` move; player name stored from `join_match`/`create_match`
- `get_messages` — reads `plugins.chat.data.messages`, optional `since` timestamp filter
- `watch` — new `messages` flag; fires on new chat/event messages with `{ type: 'message', message }` events
- `formatState` — includes `recent_messages` (last 10) in all state responses
- INSTRUCTIONS updated with `## Chat` section; autoplay prompt updated to watch `messages: true`

## Docs
- `docs/layers.md` — z-index stack
- `docs/events.md` — system events and moveCard visibility matrix