### PR TITLE
fix: add white-engine copy to mcp Containerfile

### DIFF
--- a/mcp/Containerfile
+++ b/mcp/Containerfile
@@ -2,6 +2,7 @@ FROM node:26-alpine AS build
 WORKDIR /app
 COPY mcp/package.json ./
 COPY core/ ./node_modules/@mcteamster/white-core/
+COPY engine/ ./node_modules/@mcteamster/white-engine/
 RUN npm install
 COPY mcp/index.ts ./
 RUN npx esbuild index.ts --bundle --platform=node --format=cjs --outfile=dist/index.js


### PR DESCRIPTION
The `mcp/Containerfile` was missing `COPY engine/ ./node_modules/@mcteamster/white-engine/` after PR #44 added `@mcteamster/white-engine` as an in-tree workspace. Without it, `npm install` tries to resolve the package from the public npm registry and gets a 404, causing the MCP image build to fail on every deploy.