### PR TITLE
feat: custom server support + self-hosting via tunnel

### DIFF
--- a/app/.env.development
+++ b/app/.env.development
@@ -2,6 +2,3 @@
 VITE_ORIGIN=''
 VITE_COMPRESS_IMAGES='true'
 VITE_MULTI_REGION='false'
-
-# Client Side Environment
-VITE_DEFAULT_SERVER='http://localhost:3000'

--- a/app/.env.production
+++ b/app/.env.production
@@ -6,5 +6,4 @@ VITE_MULTI_REGION='true'
 # Client Side Environment
 VITE_API_SERVER='https://api.ohnomer.com'
 VITE_CARD_API='https://rest.blankwhite.cards'
-VITE_DEFAULT_SERVER='https://eu.blankwhite.cards'
 VITE_CLARITY_ID='qjf21tnsln'

--- a/app/bin/tunnel.sh
+++ b/app/bin/tunnel.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -e
+
+# Preflight: check cloudflared is installed
+if ! command -v cloudflared &>/dev/null; then
+  echo "Error: cloudflared is not installed."
+  echo "  macOS:  brew install cloudflared"
+  echo "  Other:  https://github.com/cloudflare/cloudflared/releases"
+  exit 1
+fi
+
+# Read port from server env file, default to 3000
+PORT=3000
+ENV_FILE="$(dirname "$0")/../../server/.env.development"
+if [[ -f "$ENV_FILE" ]]; then
+  PARSED_PORT=$(grep '^PORT=' "$ENV_FILE" | cut -d= -f2)
+  [[ -n "$PARSED_PORT" ]] && PORT="$PARSED_PORT"
+fi
+
+# Cleanup on exit
+LOGFILE=$(mktemp)
+cleanup() {
+  echo ""
+  echo "Tunnel closed."
+  kill $SERVER_PID 2>/dev/null || true
+  kill $TUNNEL_PID 2>/dev/null || true
+  rm -f "$LOGFILE"
+}
+trap cleanup EXIT INT TERM
+
+# Start the game server (suppress output)
+npm run dev -w server > /dev/null 2>&1 &
+SERVER_PID=$!
+sleep 2
+
+# Start cloudflared, capture logs to temp file
+cloudflared tunnel --url "http://localhost:$PORT" > "$LOGFILE" 2>&1 &
+TUNNEL_PID=$!
+
+# Poll for the tunnel URL
+URL=""
+for i in {1..15}; do
+  URL=$(grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' "$LOGFILE" 2>/dev/null | head -1)
+  [[ -n "$URL" ]] && break
+  sleep 1
+done
+
+if [[ -z "$URL" ]]; then
+  echo "Error: Tunnel failed to start. Check your network connection."
+  cat "$LOGFILE"
+  exit 1
+fi
+
+echo ""
+echo "✔ Game server running on port $PORT"
+echo "✔ Tunnel ready:"
+echo ""
+echo "  $URL"
+echo ""
+echo "Share this URL with friends → paste into Custom server on blankwhite.cards"
+echo "Press Ctrl+C to stop."
+
+# Keep alive until ctrl+c or cloudflared exits
+wait $TUNNEL_PID

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -5,7 +5,8 @@ import { Lobby } from './Components/Lobby';
 import { About } from "./Components/About";
 import { DeckEditor } from "./Components/Editor/DeckEditor";
 import { AuthContext, AuthType, FocusContext, HotkeysContext, LoadingContext } from "./lib/contexts";
-import { GlobalBlankWhiteCardsClient, parsePathCode, getRegion, startingDeck, lobbyClients, gameClients, onDeckUpdate, deckLoading } from "./lib/clients";
+import { GlobalBlankWhiteCardsClient, parsePathCode, getRegion, startingDeck, getLobbyClient, getGameClient, onDeckUpdate, deckLoading } from "./lib/clients";
+import type { Region } from "./lib/clients";
 import { Rotate } from "./Components/Icons";
 import { useHotkeys, useWindowDimensions } from "./lib/hooks";
 import { Gallery } from "./Components/Gallery";
@@ -51,7 +52,7 @@ const App = () => {
   }, [])
 
   // Region
-  const [region, setRegion] = useState<'AP' | 'EU' | 'NA' | 'default'>(() => {
+  const [region, setRegion] = useState<Region>(() => {
     // Predefined Match IDs
     if (auth.matchID) {
       return getRegion(auth.matchID);
@@ -65,24 +66,24 @@ const App = () => {
           'eu-central-1': 'EU',
           'ap-southeast-1': 'AP',
         }
-        return awsToRegionMap[closestRegion] || 'default'
+        return awsToRegionMap[closestRegion] || 'custom'
       } else {
-        console.warn('No region autodetected, falling back to default.');
-        return 'default'
+        console.warn('No region autodetected, falling back to custom.');
+        return 'custom'
       }
     }
-    return 'default'
+    return 'custom'
   });
 
   // Multiplayer Client
-  const MultiplayerClient = gameClients[region];
+  const MultiplayerClient = getGameClient(region);
 
   // Check Credential Validity
   const [validMatch, setValidMatch] = useState(false);
   useEffect(() => {
     if (auth.matchID) {
       setRegion(getRegion(auth.matchID))
-      const lobbyClient = lobbyClients[region];
+      const lobbyClient = getLobbyClient(region);
       try {
         lobbyClient.getMatch('blank-white-cards', auth.matchID).then(async () => {
           if (auth.matchID && auth.playerID && auth.credentials) {

--- a/app/src/Components/Lobby.tsx
+++ b/app/src/Components/Lobby.tsx
@@ -260,6 +260,12 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
       const detectedRegion = getRegion(roomCode.value.toUpperCase());
       setRegion(detectedRegion);
       if (detectedRegion === 'custom') {
+        if (discordSdk) {
+          // Custom servers not supported inside Discord
+          roomCode.style.color = 'red';
+          setTimeout(() => { roomCode.style.color = ''; }, 500);
+          return;
+        }
         // Custom server — prompt for URL before connecting
         setAuth({ ...auth, matchID: roomCode.value.toUpperCase() });
         setStage('custom-server');
@@ -359,7 +365,7 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
                 <wired-card style={{ ...styles.region, backgroundColor: (region == 'AP') ? '#eee' : undefined }} onClick={() => { setRegion('AP'); }}>Asia</wired-card>
               </>
             }
-            <wired-card style={{ ...styles.region, backgroundColor: (region == 'custom') ? '#eee' : undefined }} onClick={() => { setRegion('custom'); }}>Custom</wired-card>
+            {!discordSdk && <wired-card style={{ ...styles.region, backgroundColor: (region == 'custom') ? '#eee' : undefined }} onClick={() => { setRegion('custom'); }}>Custom</wired-card>}
             {region === 'custom' && (
               <div style={{ width: '100%', margin: '0.25em 0', textAlign: 'center', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
                 <wired-input

--- a/app/src/Components/Lobby.tsx
+++ b/app/src/Components/Lobby.tsx
@@ -3,7 +3,8 @@ import { Properties } from 'csstype';
 import { Icon } from './Icons';
 import { useCallback, useContext, useEffect, useState } from "react";
 import { AuthContext, HotkeysContext } from "../lib/contexts";
-import { lobbyClients, getRegion } from "../lib/clients";
+import { getLobbyClient, getRegion, getCustomServer, setCustomServer } from "../lib/clients";
+import type { Region } from "../lib/clients";
 import { externalLink } from "../lib/hooks";
 import { discordSdk } from "../lib/discord";
 import discordLogo from '../assets/discord.svg';
@@ -132,8 +133,8 @@ const styles: { [key: string]: Properties<string | number> } = {
 interface LobbyProps {
   globalSize: number;
   deckLoading: boolean;
-  region: 'AP' | 'EU' | 'NA' | 'default';
-  setRegion: (region: 'AP' | 'EU' | 'NA' | 'default') => void;
+  region: Region;
+  setRegion: (region: Region) => void;
 }
 
 export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps) {
@@ -181,7 +182,7 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
     const playerName = checkForPlayerName();
     if (playerName) {
       // Create Match on Server
-      const { matchID } = await lobbyClients[region].createMatch('blank-white-cards', {
+      const { matchID } = await getLobbyClient(region).createMatch('blank-white-cards', {
         unlisted: true,
         numPlayers: 100, // TODO: What is a realistic upper bound?
         setupData: {
@@ -202,7 +203,7 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
         }
 
         // Join Match as playerID 0
-        const { playerCredentials } = await lobbyClients[region].joinMatch(
+        const { playerCredentials } = await getLobbyClient(region).joinMatch(
           'blank-white-cards',
           matchID,
           {
@@ -227,7 +228,7 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
       const roomCode = (document.getElementById("roomInput") as HTMLInputElement);
       if (roomCode.value.toUpperCase().match(/^[BCDFGHJKLMNPQRSTVWXZ]{4}$/)) {
         setRegion(getRegion(roomCode.value.toUpperCase()))
-        const lobbyClient = lobbyClients[getRegion(roomCode.value.toUpperCase())];
+        const lobbyClient = getLobbyClient(getRegion(roomCode.value.toUpperCase()));
         try {
           const { playerID, playerCredentials } = await lobbyClient.joinMatch(
             'blank-white-cards',
@@ -256,8 +257,15 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
   const checkForRoomCode = useCallback(() => {
     const roomCode = (document.getElementById("roomInput") as HTMLInputElement);
     if (roomCode.value && roomCode.value.toUpperCase().match(/^[BCDFGHJKLMNPQRSTVWXZ]{4}$/)) {
-      setRegion(getRegion(roomCode.value.toUpperCase()))
-      const lobbyClient = lobbyClients[getRegion(roomCode.value.toUpperCase())];
+      const detectedRegion = getRegion(roomCode.value.toUpperCase());
+      setRegion(detectedRegion);
+      if (detectedRegion === 'custom') {
+        // Custom server — prompt for URL before connecting
+        setAuth({ ...auth, matchID: roomCode.value.toUpperCase() });
+        setStage('custom-server');
+        return;
+      }
+      const lobbyClient = getLobbyClient(detectedRegion);
       lobbyClient.getMatch('blank-white-cards', roomCode.value.toUpperCase()).then(async () => {
         setAuth({ ...auth, matchID: roomCode.value.toUpperCase() });
         setStage('join');
@@ -271,9 +279,8 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
 
   const checkLobbyConnection = useCallback(() => {
     const roomCode = (document.getElementById("roomInput") as HTMLInputElement);
-    const lobbyMatches = Object.keys(lobbyClients).map((server) => {
-      const key = server as ('AP' | 'EU' | 'NA' | 'default')
-      return lobbyClients[key].listMatches('blank-white-cards');
+    const lobbyMatches = (['AP', 'EU', 'NA'] as const).map((server) => {
+      return getLobbyClient(server).listMatches('blank-white-cards');
     })
     Promise.any(lobbyMatches).then(() => {
       if (roomCode.value) {
@@ -371,14 +378,60 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
           <div style={{ ...styles.presets, display: (stage == 'create') ? undefined : 'none' }}>
             <div style={styles.subheading}>Choose Region</div>
             {
-              import.meta.env.VITE_MULTI_REGION == 'true' ?
+              import.meta.env.VITE_MULTI_REGION == 'true' &&
               <>
                 <wired-card style={{ ...styles.region, backgroundColor: (region == 'NA') ? '#eee' : undefined }} onClick={() => { setRegion('NA'); }}>America</wired-card>
                 <wired-card style={{ ...styles.region, backgroundColor: (region == 'EU') ? '#eee' : undefined }} onClick={() => { setRegion('EU'); }}>Europe</wired-card>
                 <wired-card style={{ ...styles.region, backgroundColor: (region == 'AP') ? '#eee' : undefined }} onClick={() => { setRegion('AP'); }}>Asia</wired-card>
               </>
-              : <wired-card style={{ ...styles.region, backgroundColor: (region == 'default') ? '#eee' : undefined }} onClick={() => { setRegion('default'); }}>LAN</wired-card>
             }
+            <wired-card style={{ ...styles.region, backgroundColor: (region == 'custom') ? '#eee' : undefined }} onClick={() => { setRegion('custom'); setStage('custom-server'); }}>Custom</wired-card>
+            <div
+              onClick={() => { setRegion('custom'); setStage('custom-server'); }}
+              style={{ width: '100%', textAlign: 'center', fontSize: '0.75em', color: region === 'custom' ? '#333' : '#999', cursor: 'pointer', margin: '0.1em 0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+            >
+              {getCustomServer().replace(/^https?:\/\//, '')}
+            </div>
+          </div>
+
+          {/* Custom server prompt (shared by create + join flows) */}
+          <div style={{ ...styles.presets, display: (stage == 'custom-server') ? undefined : 'none' }}>
+            <div style={styles.subheading}>Custom Server</div>
+            <div style={{ width: '100%', margin: '0.25em 0', textAlign: 'center' }}>
+              <div style={{ fontSize: '0.85em', color: '#666', marginBottom: '0.25em' }}>
+                {auth?.matchID ? `Enter the server URL for room ${auth.matchID}` : 'Enter custom server URL'}
+              </div>
+              <wired-input
+                id="customServerInput"
+                placeholder="Server URL"
+                style={{ width: '12em' }}
+                value={getCustomServer()}
+              ></wired-input>
+            </div>
+            <div style={{ ...styles.presets }}>
+              <wired-card style={styles.action} onClick={() => {
+                roomCodeError();
+                setStage(auth?.matchID ? 'landing' : 'create');
+              }}><Icon name="back" />Back</wired-card>
+              <wired-card style={styles.action} onClick={() => {
+                const input = document.getElementById('customServerInput') as HTMLInputElement;
+                const val = input?.value || input?.shadowRoot?.querySelector('input')?.value || getCustomServer();
+                setCustomServer(val);
+                if (auth?.matchID) {
+                  // Join flow — validate room exists on custom server
+                  const lobbyClient = getLobbyClient('custom');
+                  lobbyClient.getMatch('blank-white-cards', auth.matchID).then(async () => {
+                    setStage('join');
+                  }).catch(() => {
+                    roomCodeError();
+                    setStage('custom-server');
+                  });
+                } else {
+                  // Create flow — proceed to name/play
+                  setStage('create');
+                }
+              }}><Icon name="play" />Connect</wired-card>
+            </div>
           </div>
 
           <div style={{ display: (['join', 'create'].includes(stage)) ? undefined : 'none' }}>
@@ -389,6 +442,8 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
                 roomCodeError();
                 if (stage == 'join') {
                   setStage('landing');
+                } else if (stage == 'create' && region === 'custom') {
+                  setStage('custom-server');
                 } else if (stage == 'create') {
                   setStage('create-setup')
                 };
@@ -458,7 +513,7 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
 }
 
 interface NoticesProps {
-  region: 'AP' | 'EU' | 'NA' | 'default';
+  region: Region;
 }
 
 interface Notice {

--- a/app/src/Components/Lobby.tsx
+++ b/app/src/Components/Lobby.tsx
@@ -433,8 +433,7 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
           </div>
 
 
-          {/* Custom server prompt (shared by create + join flows) */}
-          {/* Custom server prompt (join flow only — TVWXZ room codes) */}
+          {/* Custom server prompt (join flow — TVWXZ room codes) */}
           <div style={{ ...styles.presets, display: (stage == 'custom-server') ? undefined : 'none' }}>
             <div style={styles.subheading}>Custom Server</div>
             <div style={styles.textentry}>

--- a/app/src/Components/Lobby.tsx
+++ b/app/src/Components/Lobby.tsx
@@ -299,7 +299,7 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
   const { hotkeys } = useContext(HotkeysContext);
   useEffect(() => {
     if (hotkeys.enter) {
-      if (stage == 'landing') {
+      if (stage == 'landing' || stage == 'down') {
         checkForRoomCode();
       } else if (stage == 'join') {
         joinGame();
@@ -326,12 +326,12 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
               </a>
             }
           </div>
-          <div style={{ display: (stage == 'down') ? undefined : 'none' }}>
-            <div style={styles.subheading}>Servers Currently Unavailable</div>
-          </div>
+          {stage === 'down' && (
+            <div style={{ ...styles.subheading, color: '#c00', fontSize: '0.85em' }}>Public servers unavailable — custom servers still work</div>
+          )}
 
-          <div style={{ display: (stage == 'landing') ? undefined : 'none' }}>
-            <wired-card style={{ ...styles.action, fontSize: '1.5em' }} onClick={() => { setStage('create-setup') }}>
+          <div style={{ display: (stage == 'landing' || stage == 'down') ? undefined : 'none' }}>
+            <wired-card style={{ ...styles.action, fontSize: '1.5em' }} onClick={() => { setStage('create-region') }}>
               Create New Game
             </wired-card>
             <div>or</div>
@@ -348,7 +348,64 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
             <wired-card style={{ ...styles.code, fontSize: '1.5em', color: 'grey' }}>{auth?.matchID}</wired-card>
           </div>
 
-          <div style={{ ...styles.presets, display: (stage == 'create-setup') ? undefined : 'none' }}>
+          {/* Step 1: Choose Region */}
+          <div style={{ ...styles.presets, display: (stage == 'create-region') ? undefined : 'none' }}>
+            <div style={styles.subheading}>Choose Region</div>
+            {
+              import.meta.env.VITE_MULTI_REGION == 'true' &&
+              <>
+                <wired-card style={{ ...styles.region, backgroundColor: (region == 'NA') ? '#eee' : undefined }} onClick={() => { setRegion('NA'); }}>America</wired-card>
+                <wired-card style={{ ...styles.region, backgroundColor: (region == 'EU') ? '#eee' : undefined }} onClick={() => { setRegion('EU'); }}>Europe</wired-card>
+                <wired-card style={{ ...styles.region, backgroundColor: (region == 'AP') ? '#eee' : undefined }} onClick={() => { setRegion('AP'); }}>Asia</wired-card>
+              </>
+            }
+            <wired-card style={{ ...styles.region, backgroundColor: (region == 'custom') ? '#eee' : undefined }} onClick={() => { setRegion('custom'); }}>Custom</wired-card>
+            {region === 'custom' && (
+              <div style={{ width: '100%', margin: '0.25em 0', textAlign: 'center', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+                <wired-input
+                  id="customServerInput"
+                  placeholder="http://localhost:3000"
+                  style={{ width: '12em' }}
+                  onBlur={(e: React.FocusEvent<HTMLInputElement>) => {
+                    const val = (e.target as HTMLInputElement).value || (e.target?.shadowRoot?.querySelector('input') as HTMLInputElement)?.value;
+                    if (val) setCustomServer(val);
+                  }}
+                ></wired-input>
+                <span style={{ cursor: 'pointer', fontSize: '1.5em', color: '#000', marginLeft: '0.25em' }} onClick={() => {
+                  const input = document.getElementById('customServerInput') as HTMLInputElement;
+                  const inner = input?.shadowRoot?.querySelector('input') as HTMLInputElement;
+                  if (inner) inner.value = '';
+                  if (input) input.value = '';
+                }}>×</span>
+              </div>
+            )}
+            <div style={{ ...styles.presets }}>
+              <wired-card style={styles.action} onClick={() => { roomCodeError(); setStage('landing') }}><Icon name="back" />Back</wired-card>
+              <wired-card style={styles.action} onClick={() => {
+                if (region === 'custom') {
+                  // Save the URL and validate connectivity before proceeding
+                  const input = document.getElementById('customServerInput') as HTMLInputElement;
+                  const val = input?.value || input?.shadowRoot?.querySelector('input')?.value || getCustomServer();
+                  setCustomServer(val);
+                  getLobbyClient('custom').listMatches('blank-white-cards').then(() => {
+                    setStage('create-deck');
+                  }).catch(() => {
+                    // Flash the input red to indicate connection failure
+                    const el = document.getElementById('customServerInput') as HTMLElement;
+                    if (el) {
+                      el.style.color = 'red';
+                      setTimeout(() => { el.style.color = ''; }, 500);
+                    }
+                  });
+                } else {
+                  setStage('create-deck');
+                }
+              }}><Icon name="done" />Confirm</wired-card>
+            </div>
+          </div>
+
+          {/* Step 2: Select Deck */}
+          <div style={{ ...styles.presets, display: (stage == 'create-deck') ? undefined : 'none' }}>
             <div style={styles.subheading}>Select a Starting Deck</div>
             <wired-card style={{ ...styles.action, backgroundColor: (preset == 'blank') ? '#eee' : undefined }} onClick={() => { setPreset('blank'); }}><Icon name="copy" />Blank</wired-card>
             <wired-card style={{ ...styles.action, backgroundColor: (preset == 'global') ? '#eee' : undefined }} onClick={() => { setPreset('global'); }}><Icon name="global" />Global</wired-card>
@@ -370,66 +427,63 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
               {preset == 'party-2026' && 'A curated 100 card party deck — dares, chaos mechanics, and social fun.'}
             </div>
             <div style={{ ...styles.presets }}>
-              <wired-card style={styles.action} onClick={() => { roomCodeError(); setStage('landing') }}><Icon name="back" />Back</wired-card>
+              <wired-card style={styles.action} onClick={() => { roomCodeError(); setStage('create-region') }}><Icon name="back" />Back</wired-card>
               <wired-card style={styles.action} onClick={() => { roomCodeError(); setStage('create') }}><Icon name="done" />Confirm</wired-card>
             </div>
           </div>
 
-          <div style={{ ...styles.presets, display: (stage == 'create') ? undefined : 'none' }}>
-            <div style={styles.subheading}>Choose Region</div>
-            {
-              import.meta.env.VITE_MULTI_REGION == 'true' &&
-              <>
-                <wired-card style={{ ...styles.region, backgroundColor: (region == 'NA') ? '#eee' : undefined }} onClick={() => { setRegion('NA'); }}>America</wired-card>
-                <wired-card style={{ ...styles.region, backgroundColor: (region == 'EU') ? '#eee' : undefined }} onClick={() => { setRegion('EU'); }}>Europe</wired-card>
-                <wired-card style={{ ...styles.region, backgroundColor: (region == 'AP') ? '#eee' : undefined }} onClick={() => { setRegion('AP'); }}>Asia</wired-card>
-              </>
-            }
-            <wired-card style={{ ...styles.region, backgroundColor: (region == 'custom') ? '#eee' : undefined }} onClick={() => { setRegion('custom'); setStage('custom-server'); }}>Custom</wired-card>
-            <div
-              onClick={() => { setRegion('custom'); setStage('custom-server'); }}
-              style={{ width: '100%', textAlign: 'center', fontSize: '0.75em', color: region === 'custom' ? '#333' : '#999', cursor: 'pointer', margin: '0.1em 0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-            >
-              {getCustomServer().replace(/^https?:\/\//, '')}
-            </div>
-          </div>
 
           {/* Custom server prompt (shared by create + join flows) */}
+          {/* Custom server prompt (join flow only — TVWXZ room codes) */}
           <div style={{ ...styles.presets, display: (stage == 'custom-server') ? undefined : 'none' }}>
             <div style={styles.subheading}>Custom Server</div>
-            <div style={{ width: '100%', margin: '0.25em 0', textAlign: 'center' }}>
-              <div style={{ fontSize: '0.85em', color: '#666', marginBottom: '0.25em' }}>
-                {auth?.matchID ? `Enter the server URL for room ${auth.matchID}` : 'Enter custom server URL'}
-              </div>
-              <wired-input
-                id="customServerInput"
-                placeholder="Server URL"
-                style={{ width: '12em' }}
-                value={getCustomServer()}
-              ></wired-input>
+            <div style={styles.textentry}>
+              <wired-input style={styles.name} id="customServerJoinInput" placeholder="http://localhost:3000"></wired-input>
+              <span style={{ cursor: 'pointer', fontSize: '1.5em', color: '#000', marginLeft: '0.25em' }} onClick={() => {
+                const input = document.getElementById('customServerJoinInput') as HTMLInputElement;
+                const inner = input?.shadowRoot?.querySelector('input') as HTMLInputElement;
+                if (inner) inner.value = '';
+                if (input) input.value = '';
+              }}>×</span>
+            </div>
+            <div style={styles.subheading}>Room Code</div>
+            <div style={styles.textentry}>
+              <wired-input style={{ ...styles.code, fontSize: '1.5em' }} id="customServerRoomInput" placeholder="&nbsp;Room" maxlength={4} value={auth?.matchID} key={`room-${auth?.matchID}`}></wired-input>
             </div>
             <div style={{ ...styles.presets }}>
               <wired-card style={styles.action} onClick={() => {
-                roomCodeError();
-                setStage(auth?.matchID ? 'landing' : 'create');
+                setAuth({});
+                setStage('landing');
               }}><Icon name="back" />Back</wired-card>
               <wired-card style={styles.action} onClick={() => {
-                const input = document.getElementById('customServerInput') as HTMLInputElement;
-                const val = input?.value || input?.shadowRoot?.querySelector('input')?.value || getCustomServer();
-                setCustomServer(val);
-                if (auth?.matchID) {
-                  // Join flow — validate room exists on custom server
-                  const lobbyClient = getLobbyClient('custom');
-                  lobbyClient.getMatch('blank-white-cards', auth.matchID).then(async () => {
-                    setStage('join');
-                  }).catch(() => {
-                    roomCodeError();
-                    setStage('custom-server');
-                  });
-                } else {
-                  // Create flow — proceed to name/play
-                  setStage('create');
+                const roomInput = document.getElementById('customServerRoomInput') as HTMLInputElement;
+                const urlInput = document.getElementById('customServerJoinInput') as HTMLInputElement;
+                const roomVal = (roomInput?.value || roomInput?.shadowRoot?.querySelector('input')?.value || '').toUpperCase();
+                const urlVal = urlInput?.value || urlInput?.shadowRoot?.querySelector('input')?.value || getCustomServer();
+
+                // Validate room code format
+                if (!roomVal.match(/^[BCDFGHJKLMNPQRSTVWXZ]{4}$/)) {
+                  roomInput.style.color = 'red';
+                  setTimeout(() => { roomInput.style.color = ''; }, 500);
+                  return;
                 }
+
+                setCustomServer(urlVal);
+                setAuth({ ...auth, matchID: roomVal });
+
+                // Try to connect and find the room
+                const lobbyClient = getLobbyClient('custom');
+                lobbyClient.getMatch('blank-white-cards', roomVal).then(async () => {
+                  setStage('join');
+                }).catch((err) => {
+                  if (err?.message?.includes('404') || err?.status === 404) {
+                    roomInput.style.color = 'red';
+                    setTimeout(() => { roomInput.style.color = ''; }, 500);
+                  } else {
+                    urlInput.style.color = 'red';
+                    setTimeout(() => { urlInput.style.color = ''; }, 500);
+                  }
+                });
               }}><Icon name="play" />Connect</wired-card>
             </div>
           </div>
@@ -442,10 +496,8 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
                 roomCodeError();
                 if (stage == 'join') {
                   setStage('landing');
-                } else if (stage == 'create' && region === 'custom') {
-                  setStage('custom-server');
                 } else if (stage == 'create') {
-                  setStage('create-setup')
+                  setStage('create-deck');
                 };
               }}><Icon name="back" />Back</wired-card>
               <wired-card id='enterGameButton' style={styles.action} onClick={() => {

--- a/app/src/lib/clients.ts
+++ b/app/src/lib/clients.ts
@@ -149,6 +149,7 @@ export function getLobbyClient(region: Region): LobbyClient {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
+// TODO: boardgame.io Client() generic variance prevents proper typing here
 export function getGameClient(region: Region): any {
   const url = getServerUrl(region);
   if (!gameClientCache.has(url)) {

--- a/app/src/lib/clients.ts
+++ b/app/src/lib/clients.ts
@@ -111,59 +111,71 @@ export const GlobalBlankWhiteCardsClient = Client({
 });
 
 // Multiplayer Custom Rooms
-export const SERVERS = {
+export type Region = 'AP' | 'EU' | 'NA' | 'custom';
+
+export const SERVERS: Record<string, string> = {
   'AP': 'https://ap.blankwhite.cards',
   'EU': 'https://eu.blankwhite.cards',
   'NA': 'https://na.blankwhite.cards',
-}
-
-export const lobbyClients: Record<'AP' | 'EU' | 'NA' | 'default', LobbyClient> = {
-  AP: new LobbyClient({ server: SERVERS.AP }),
-  EU: new LobbyClient({ server: SERVERS.EU }),
-  NA: new LobbyClient({ server: SERVERS.NA }),
-  default: new LobbyClient({ server: import.meta.env.VITE_DEFAULT_SERVER }),
 };
 
-export const gameClients = {
-  AP: Client({
-    game: BlankWhiteCards,
-    board: BlankWhiteCardsBoard,
-    multiplayer: SocketIO({ server: SERVERS.AP }),
-  }),
-  EU: Client({
-    game: BlankWhiteCards,
-    board: BlankWhiteCardsBoard,
-    multiplayer: SocketIO({ server: SERVERS.EU }),
-  }),
-  NA: Client({
-    game: BlankWhiteCards,
-    board: BlankWhiteCardsBoard,
-    multiplayer: SocketIO({ server: SERVERS.NA }),
-  }),
-  default: Client({
-    game: BlankWhiteCards,
-    board: BlankWhiteCardsBoard,
-    multiplayer: SocketIO({ server: import.meta.env.VITE_DEFAULT_SERVER }),
-  }),
+const CUSTOM_SERVER_KEY = 'customServerUrl';
+const DEFAULT_CUSTOM_SERVER = 'http://localhost:3000';
+
+export function getCustomServer(): string {
+  return localStorage.getItem(CUSTOM_SERVER_KEY) || DEFAULT_CUSTOM_SERVER;
 }
 
-export const getRegion = (room: string) => {
+export function setCustomServer(url: string): void {
+  localStorage.setItem(CUSTOM_SERVER_KEY, url);
+}
+
+export function getServerUrl(region: Region): string {
+  if (region === 'custom') return getCustomServer();
+  return SERVERS[region];
+}
+
+// Lazy client factories with URL-keyed caches
+const lobbyClientCache = new Map<string, LobbyClient>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const gameClientCache = new Map<string, any>();
+
+export function getLobbyClient(region: Region): LobbyClient {
+  const url = getServerUrl(region);
+  if (!lobbyClientCache.has(url)) {
+    lobbyClientCache.set(url, new LobbyClient({ server: url }));
+  }
+  return lobbyClientCache.get(url)!;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getGameClient(region: Region): any {
+  const url = getServerUrl(region);
+  if (!gameClientCache.has(url)) {
+    gameClientCache.set(url, Client({
+      game: BlankWhiteCards,
+      board: BlankWhiteCardsBoard,
+      multiplayer: SocketIO({ server: url }),
+    }));
+  }
+  return gameClientCache.get(url)!;
+}
+
+export const getRegion = (room: string): Region => {
   if (import.meta.env.VITE_MULTI_REGION === 'true') {
-    // This implementation is specific to a 3 global region server setup, adjust balancing accordingly here and in server.ts
     if (room.match(/^[BCDFGHJKLMNPQRSTVWXZ]{4}$/)) {
-      // Set server region based on room code
       if (room.match(/[BCDFG]$/)) {
         return 'AP';
       } else if (room.match(/[HJKLM]$/)) {
         return 'EU';
       } else if (room.match(/[NPQRS]$/)) {
         return 'NA';
-      } else { // Fallback to default server (TVWXZ)
-        return 'default';
+      } else { // Custom server (TVWXZ)
+        return 'custom';
       }
     }
   }
-  return 'default';
+  return 'custom';
 }
 
 export const parsePathCode = () => {

--- a/app/src/lib/editor.ts
+++ b/app/src/lib/editor.ts
@@ -3,7 +3,7 @@ import { useParams } from 'react-router';
 import { Card } from '@mcteamster/white-core';
 import { sanitiseCard } from './data';
 import { dbManager } from './indexedDB';
-import { getRegion, SERVERS } from './clients';
+import { getRegion, getServerUrl } from './clients';
 
 export interface DeckEditorState {
   cards: Card[];
@@ -49,7 +49,7 @@ export const useDeckEditor = () => {
       if (deckId) {
         try {
           const region = getRegion(deckId);
-          const serverUrl = region === 'default' ? import.meta.env.VITE_DEFAULT_SERVER : SERVERS[region];
+          const serverUrl = getServerUrl(region);
           const response = await fetch(`${serverUrl}/export/${deckId}`);
           if (response.ok) {
             const rawData = await response.text();

--- a/docs/local.md
+++ b/docs/local.md
@@ -19,21 +19,6 @@ npm run local
 ```
 This will run a `boardgame.io` server at http://localhost:3000
 
-[Optional] If you'd like to host across your local network, modify the LAN IP Address and/or PORT in `server/.env.development`:
-```
-NODE_ENV=development
-PORT=<PORT>
-ORIGIN=http://<YOUR_LAN_IP_ADDRESS>:<PORT>
-```
-
-And update `app/.env.development`:
-```
-VITE_ORIGIN='http://<YOUR_LAN_IP_ADDRESS>:5173'
-VITE_COMPRESS_IMAGES='true'
-VITE_MULTI_REGION='false'
-VITE_DEFAULT_SERVER='http://<YOUR_LAN_IP_ADDRESS>:<PORT>'
-```
-
 ### 3. Start hosting the Client
 Open a new terminal and run:
 ```
@@ -49,7 +34,49 @@ npm run preview -w app
 
 Congratulations! You can now start playing or extending `Blank White Cards` to your heart's content!
 
-### 4. [OPTIONAL] Production Builds
+### 4. Remote Play (Self-Hosting for Friends)
+
+Want friends on other networks to join your game? Use `cloudflared` to expose your local server:
+
+**Install cloudflared:**
+- macOS: `brew install cloudflared`
+- Linux: [Download from GitHub](https://github.com/cloudflare/cloudflared/releases)
+- Windows: [Download from GitHub](https://github.com/cloudflare/cloudflared/releases)
+
+**Start the server with a tunnel:**
+```
+npm run tunnel
+```
+
+This starts the game server (using the port from `server/.env.development`) and creates a public tunnel. Look for a URL like:
+```
+https://random-word-here.trycloudflare.com
+```
+
+**Share with friends:**
+1. Send them the tunnel URL
+2. They go to https://blankwhite.cards
+3. Create or join a game → select **Custom** server → paste your tunnel URL
+4. Play!
+
+**Notes:**
+- No account needed — quick tunnels are free and anonymous
+- The URL changes each time you restart (fine for game sessions)
+- WebSocket/real-time gameplay works through the tunnel
+- Limit: 200 concurrent requests (more than enough for 2-10 players)
+
+### 5. [OPTIONAL] LAN Play
+
+For same-network play without a tunnel, other devices can connect to your machine's LAN IP directly. Modify `server/.env.development`:
+```
+NODE_ENV=development
+PORT=3000
+ORIGIN=
+```
+
+Players on the same network go to https://blankwhite.cards, select **Custom** server, and enter `http://<YOUR_LAN_IP>:<PORT>` (default port is 3000, configurable in `server/.env.development`).
+
+### 6. [OPTIONAL] Production Builds
 This section assumes you have web servers set up and properly configured for production network traffic [see sample architecture](./cloud.md)
 
 Update `app/.env.production` with the details of your hosting setup:
@@ -59,7 +86,6 @@ VITE_COMPRESS_IMAGES='true'
 VITE_MULTI_REGION='false'
 VITE_API_SERVER='<COMMON_API>'
 VITE_CARD_API='<CARD_API_ENDPOINT>'
-VITE_DEFAULT_SERVER='<GAME_SERVER>'
 ```
 
 Update `server/.env.production`:
@@ -80,7 +106,7 @@ Run the game server:
 npm run serve
 ```
 
-### 5. [OPTIONAL] MCP Server
+### 7. [OPTIONAL] MCP Server
 The MCP server lets AI agents play Blank White Cards via the [Model Context Protocol](https://modelcontextprotocol.io/).
 
 By default, the MCP server connects to the public game servers (ap/eu/na.blankwhite.cards) based on the room code. To point it at your own server instead, set the `GAME_SERVER_URL` environment variable:
@@ -130,7 +156,7 @@ Add to your MCP client config:
 }
 ```
 
-### 6. Project Structure
+### 8. Project Structure
 ```
 white/
 ├── core/       ← Shared game logic (Game.ts, Cards.ts)

--- a/docs/local.md
+++ b/docs/local.md
@@ -36,45 +36,40 @@ Congratulations! You can now start playing or extending `Blank White Cards` to y
 
 ### 4. Remote Play (Self-Hosting for Friends)
 
-Want friends on other networks to join your game? Use `cloudflared` to expose your local server:
+Want friends on other networks to join your game? You can use `cloudflared` to expose your local server via a temporary public URL.
 
-**Install cloudflared:**
+First, install cloudflared:
 - macOS: `brew install cloudflared`
-- Linux: [Download from GitHub](https://github.com/cloudflare/cloudflared/releases)
-- Windows: [Download from GitHub](https://github.com/cloudflare/cloudflared/releases)
+- Linux/Windows: [Download from GitHub](https://github.com/cloudflare/cloudflared/releases)
 
-**Start the server with a tunnel:**
+Then run:
 ```
 npm run tunnel
 ```
 
-This starts the game server (using the port from `server/.env.development`) and creates a public tunnel. Look for a URL like:
+This starts the game server and opens a tunnel. You'll see a URL like:
 ```
 https://random-word-here.trycloudflare.com
 ```
 
-**Share with friends:**
-1. Send them the tunnel URL
-2. They go to https://blankwhite.cards
-3. Create or join a game → select **Custom** server → paste your tunnel URL
-4. Play!
+Send that URL to your friends. They go to https://blankwhite.cards, create or join a game, select **Custom** server, and paste your URL. That's it!
 
-**Notes:**
-- No account needed — quick tunnels are free and anonymous
-- The URL changes each time you restart (fine for game sessions)
-- WebSocket/real-time gameplay works through the tunnel
-- Limit: 200 concurrent requests (more than enough for 2-10 players)
+The URL changes each time you restart — that's fine for game sessions. No Cloudflare account needed. WebSockets work through the tunnel.
+
+> ⚠️ **Heads up:** This exposes your game server to the internet. The server only handles ephemeral card game state — no files, no credentials, nothing persistent — but you should still only share the URL with people you trust, and stop the tunnel (`Ctrl+C`) when you're done. Quick tunnels are subject to [Cloudflare's Terms of Service](https://www.cloudflare.com/website-terms/).
+
+Note: Custom servers don't work from inside the Discord Activity — players there can only connect to the official servers. Friends will need to use the browser client at https://blankwhite.cards to join your tunnel.
 
 ### 5. [OPTIONAL] LAN Play
 
-For same-network play without a tunnel, other devices can connect to your machine's LAN IP directly. Modify `server/.env.development`:
+If everyone's on the same network, you don't need a tunnel. Just leave `ORIGIN` empty in `server/.env.development`:
 ```
 NODE_ENV=development
 PORT=3000
 ORIGIN=
 ```
 
-Players on the same network go to https://blankwhite.cards, select **Custom** server, and enter `http://<YOUR_LAN_IP>:<PORT>` (default port is 3000, configurable in `server/.env.development`).
+Other players go to https://blankwhite.cards, select **Custom** server, and enter your machine's LAN IP (e.g. `http://192.168.1.42:3000`).
 
 ### 6. [OPTIONAL] Production Builds
 This section assumes you have web servers set up and properly configured for production network traffic [see sample architecture](./cloud.md)

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "pull:global": "npm run pull:global -w app",
     "serve": "npm run start -w server",
     "local": "npm run dev -w server",
+    "tunnel": "bash app/bin/tunnel.sh",
     "serve:mcp": "npm run serve -w mcp",
     "local:mcp": "npm run dev -w mcp",
     "version:bump": "npm version patch --workspaces --include-workspace-root"

--- a/server/index.ts
+++ b/server/index.ts
@@ -20,10 +20,18 @@ const roomCodeGen = () => {
   return roomCode
 };
 
+// CORS Configuration
+// Deployed servers: set ORIGIN to restrict (e.g. 'https://blankwhite.cards')
+// Self-hosted: leave unset for permissive CORS (allows any origin)
+const corsOrigin = process.env.ORIGIN;
+const origins = corsOrigin
+  ? [corsOrigin, Origins.LOCALHOST]
+  : [/.*/]; // Allow all origins when not configured (self-hosted default)
+
 // Initialise Server
 const server = Server({
   games: [BlankWhiteCards],
-  origins: [process.env.ORIGIN || '', Origins.LOCALHOST],
+  origins,
   uuid: roomCodeGen,
   generateCredentials: () => nanoid(),
 });


### PR DESCRIPTION
## Summary

Enables players to connect the official `blankwhite.cards` client to any game server URL (self-hosted, tunneled, etc). Includes a one-command tunnel script for sharing games with friends.

## Changes

- **`clients.ts`**: Lazy cached factory (`getLobbyClient`/`getGameClient`), `Region` type, custom URL in localStorage
- **Lobby UI**: Region → Deck → Name create flow. Custom server button with inline URL input. TVWXZ room codes prompt for server URL before joining.
- **Server CORS**: Defaults to allow-all when `ORIGIN` unset — enables self-hosted servers. Production unchanged.
- **`editor.ts`**: Uses `getServerUrl()` instead of manual resolution
- **Tunnel script** (`app/bin/tunnel.sh`): Starts game server + cloudflared, extracts URL cleanly, proper cleanup on exit
- **Discord guard**: Custom server option hidden inside Discord Activity (network sandbox incompatibility)
- **Docs**: Rewrote `docs/local.md` with remote play, LAN, and tunnel sections

## Design decisions

- Cache keyed by URL (not region) — supports changing custom URL mid-session
- Custom URL persists in localStorage with `localhost:3000` as default fallback
- TVWXZ codes (self-hosted servers) always show prompt — no silent fallback
- `ORIGIN` env var reused (already set in production) instead of introducing new var
- Custom servers disabled in Discord (can't proxy arbitrary domains safely)

Closes BWC-7, Closes BWC-8