### PR TITLE
feat: extended hotkeys (WASD, spacebar pickup, focus guard)

### DIFF
--- a/app/src/Components/ActionSpace.tsx
+++ b/app/src/Components/ActionSpace.tsx
@@ -9,7 +9,7 @@ import { useState, useEffect, useContext, useRef, useCallback } from 'react';
 //@ts-expect-error: JS Module
 import { undo, redo, strokes, sketchpad, fillWhite, cycleBrushSize, getCurrentBrushSize, getMode, setMode as setCanvasMode, MODE_DRAW, MODE_ERASE, MODE_DOTS } from '../Canvas.js';
 import { Link, useNavigate } from 'react-router';
-import { AuthContext, FocusContext, LoadingContext } from '../lib/contexts.ts';
+import { AuthContext, FocusContext, HotkeysContext, LoadingContext } from '../lib/contexts.ts';
 import { openDeckEditor } from '../lib/data.ts';
 import { Loader } from './Loader.tsx';
 import { submitGlobalCard } from '../lib/clients.ts';
@@ -45,6 +45,21 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
   const pile = getCardsByLocation(G.cards, "pile");
   const discard = getCardsByLocation(G.cards, "discard");
   const hand = getCardsByLocation(getCardsByOwner(G.cards, playerID || "0"), "hand");
+
+  const doPickup = useCallback(() => {
+    if (!loading && mode === 'play') {
+      setLoading(true);
+      moves.pickupCard(true);
+    }
+  }, [loading, mode, setLoading, moves]);
+
+  // Spacebar pickup when no card is focused
+  const { hotkeys } = useContext(HotkeysContext);
+  useEffect(() => {
+    if (hotkeys.space && !focus?.id) {
+      doPickup();
+    }
+  }, [hotkeys.space, focus?.id, doPickup]);
 
   useEffect(() => {
     const create = (document.getElementById('create') as HTMLElement);
@@ -313,10 +328,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
       <wired-card style={styles.button} onClick={() => { setMode('menu') }} elevation={2}><Icon name='menu' />Menu</wired-card>
       <wired-card style={{ ...styles.button, width: '9.75em', margin: '0' }} onClick={() => {
         if (deck.length > 0) {
-          if (!loading) {
-            setLoading(true);
-            moves.pickupCard(true);
-          }
+          doPickup();
         } else if (G.cards.length == 0) {
           if (playerID == '0') {
             setMode('menu-tools-loader')
@@ -324,10 +336,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
             setMode('create-sketch')
           }
         } else if (pile.length + discard.length > 0) {
-          if (!loading) {
-            setLoading(true);
-            moves.pickupCard(true);
-          }
+          doPickup();
         } else {
           if (playerID == '0') {
             setMode('menu-tools-reset')

--- a/app/src/Components/Focus.tsx
+++ b/app/src/Components/Focus.tsx
@@ -321,15 +321,15 @@ export function Focus(props: BoardProps<GameState>) {
     if (card) {
       const owned = card.owner == props.playerID;
 
-      if (hotkeys.escape) {
+      if (hotkeys.escape || hotkeys.q) {
         unfocusCards();
-      } else if (props.isMultiplayer && owned && hotkeys.enter) {
+      } else if (props.isMultiplayer && owned && (hotkeys.enter || hotkeys.f)) {
         setSendCardMode(true);
-      } else if (hotkeys.left && card.id) {
+      } else if ((hotkeys.left || hotkeys.a) && card.id) {
         changeFocus('prev');
-      } else if (hotkeys.right && card.id) {
+      } else if ((hotkeys.right || hotkeys.d) && card.id) {
         changeFocus('next');
-      } else if (props.isMultiplayer && owned && hotkeys.up) {
+      } else if (props.isMultiplayer && owned && (hotkeys.up || hotkeys.w)) {
         if (card.location != "table") {
           const adjacentCard = getAdjacentCard(props.G.cards, card.id, 'prev', props.playerID) || getAdjacentCard(props.G.cards, card.id, 'next', props.playerID);
           props.moves.moveCard(card.id, "table");
@@ -341,7 +341,7 @@ export function Focus(props: BoardProps<GameState>) {
         } else {
           unfocusCards();
         }
-      } else if (props.isMultiplayer && owned && hotkeys.down) {
+      } else if (props.isMultiplayer && owned && (hotkeys.down || hotkeys.s)) {
         if (card.location != "hand") {
           const adjacentCard = getAdjacentCard(props.G.cards, card.id, 'prev', props.playerID) || getAdjacentCard(props.G.cards, card.id, 'next', props.playerID);
           props.moves.moveCard(card.id, "hand");
@@ -353,7 +353,7 @@ export function Focus(props: BoardProps<GameState>) {
         } else {
           unfocusCards();
         }
-      } else if (owned && hotkeys.delete) {
+      } else if (owned && (hotkeys.delete || hotkeys.x)) {
         const adjacentCard = getAdjacentCard(props.G.cards, card.id, 'prev', props.playerID) || getAdjacentCard(props.G.cards, card.id, 'next', props.playerID);
         props.moves.moveCard(card.id, "discard");
         if (adjacentCard) {
@@ -361,7 +361,7 @@ export function Focus(props: BoardProps<GameState>) {
         } else {
           unfocusCards();
         }
-      } else if (props.isMultiplayer && owned && hotkeys.backspace) {
+      } else if (props.isMultiplayer && owned && (hotkeys.backspace || hotkeys.r)) {
         const adjacentCard = getAdjacentCard(props.G.cards, card.id, 'prev', props.playerID) || getAdjacentCard(props.G.cards, card.id, 'next', props.playerID);
         props.moves.moveCard(card.id, "deck");
         if (adjacentCard) {

--- a/app/src/Components/Gallery.tsx
+++ b/app/src/Components/Gallery.tsx
@@ -193,15 +193,15 @@ export function Gallery() {
       }
     }
 
-    if (hotkeys.left) {
+    if (hotkeys.left || hotkeys.a) {
       setTimeout(() => {
         changeViewed('old');
       }, 0)
-    } else if (hotkeys.right) {
+    } else if (hotkeys.right || hotkeys.d) {
       setTimeout(() => {
         changeViewed('new');
       }, 0)
-    } else if (hotkeys.escape) {
+    } else if (hotkeys.escape || hotkeys.q) {
       setTimeout(() => {
         navigate('/card');
       }, 0)

--- a/app/src/lib/contexts.ts
+++ b/app/src/lib/contexts.ts
@@ -47,6 +47,14 @@ export interface HotkeysType {
   enter?: boolean | undefined,
   escape?: boolean | undefined,
   space?: boolean | undefined,
+  q?: boolean | undefined,
+  w?: boolean | undefined,
+  a?: boolean | undefined,
+  s?: boolean | undefined,
+  d?: boolean | undefined,
+  f?: boolean | undefined,
+  r?: boolean | undefined,
+  x?: boolean | undefined,
 }
 
 export interface HotkeysContextType {

--- a/app/src/lib/hooks.ts
+++ b/app/src/lib/hooks.ts
@@ -42,10 +42,22 @@ export const useHotkeys = ({ hotkeys, setHotkeys}: HotkeysContextType) => {
       Enter: 'enter',
       Escape: 'escape',
       Space: 'space',
+      KeyQ: 'q',
+      KeyW: 'w',
+      KeyA: 'a',
+      KeyS: 's',
+      KeyD: 'd',
+      KeyF: 'f',
+      KeyR: 'r',
+      KeyX: 'x',
     }
 
     const keyDownHandler = (event: globalThis.KeyboardEvent) => {
+      const tag = document.activeElement?.tagName?.toUpperCase();
+      const isInputFocused = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'WIRED-INPUT' || tag === 'WIRED-TEXTAREA';
+      if (isInputFocused) return;
       if (hotkeyMapping[event.code as keyof typeof hotkeyMapping]) {
+        event.preventDefault();
         const hotkeyEvent: { [key: string]: boolean } = {};
         // Slow Down repeated keys
         if (keyTicks.current > 6 || keyTicks.current == 0) {

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -1,0 +1,23 @@
+# Hotkeys
+
+| | | | |
+|:---:|:---:|:---:|:---:|
+| Q<br>unfocus | W<br>table | [E]<br>edit | R<br>return to deck |
+| A<br>previous | S<br>hand | D<br>next | F<br>send |
+| | X<br>discard | | |
+| | | Space<br>pickup / pile | |
+
+## All Mappings
+
+| Action | Right Hand | Left Hand | Conditions |
+|--------|:----------:|:---------:|------------|
+| Previous card | ← | A | |
+| Next card | → | D | |
+| Move to table | ↑ | W | Multiplayer, owned card |
+| Move to hand | ↓ | S | Multiplayer, owned card |
+| Play to pile | Space | Space | Card focused |
+| Pick up from deck | Space | Space | No card focused |
+| Enter send mode | Enter | F | Multiplayer, owned card |
+| Return to deck | Backspace | R | Multiplayer, owned card |
+| Discard | Delete | X | Owned card |
+| Unfocus card | Escape | Q | |


### PR DESCRIPTION
## Summary

Adds left-hand keyboard shortcuts for card actions, spacebar-to-pickup, and a focus guard that prevents hotkeys from interfering with text input.

## Changes

- **Focus guard**: Suppresses all hotkeys when a text input has focus (chat console, room code input)
- **WASD+ aliases**: Q/W/A/S/D/F/R/X map to unfocus/table/prev/hand/next/send/return/discard in consumers
- **Spacebar pickup**: Picks up from deck when no card is focused, via `doPickup()` with proper debounce
- **preventDefault**: All handled hotkeys call `event.preventDefault()` to stop browser defaults (scroll, back)
- **Literal key state**: Hotkey layer maps physical keys to their identity (`hotkeys.a`, `hotkeys.w`); consumers decide semantics with `||` patterns
- **docs/hotkeys.md**: Key layout grid and full mapping reference

## Testing

- Verified spacebar pickup (3 cards drawn)
- Verified W (table), R (return to deck), X (discard), Q (unfocus), F (send mode)
- Verified A/D navigation between cards
- Verified focus guard (typed room code without triggering hotkeys)
- Verified Lobby Enter hotkey advances stages
- TypeScript compiles clean

Closes BWC-61