### PR TITLE
feat: custom server UX improvements

### DIFF
--- a/app/src/Components/Lobby.tsx
+++ b/app/src/Components/Lobby.tsx
@@ -3,7 +3,7 @@ import { Properties } from 'csstype';
 import { Icon } from './Icons';
 import { useCallback, useContext, useEffect, useState } from "react";
 import { AuthContext, HotkeysContext } from "../lib/contexts";
-import { getLobbyClient, getRegion, getCustomServer, setCustomServer } from "../lib/clients";
+import { getLobbyClient, getRegion, getCustomServer, setCustomServer, resolveCustomServer } from "../lib/clients";
 import type { Region } from "../lib/clients";
 import { externalLink } from "../lib/hooks";
 import { discordSdk } from "../lib/discord";
@@ -130,6 +130,60 @@ const styles: { [key: string]: Properties<string | number> } = {
   }
 }
 
+function CustomServerInput({ id, onConnect, autoFocus }: { id: string; onConnect: () => void; autoFocus?: boolean }) {
+  const saved = getCustomServer();
+  const defaultValue = saved !== 'http://localhost:3000' ? saved : '';
+
+  useEffect(() => {
+    setTimeout(() => {
+      const el = document.getElementById(id) as HTMLInputElement;
+      const inner = el?.shadowRoot?.querySelector('input') as HTMLInputElement;
+      if (defaultValue) {
+        if (inner) inner.value = defaultValue;
+        else if (el) el.value = defaultValue;
+      }
+    }, 50);
+  }, []);
+
+  useEffect(() => {
+    if (autoFocus) {
+      setTimeout(() => {
+        const el = document.getElementById(id) as HTMLInputElement;
+        const inner = el?.shadowRoot?.querySelector('input') as HTMLInputElement;
+        if (inner) inner.focus();
+        else if (el) el.focus();
+      }, 50);
+    }
+  }, [autoFocus]);
+
+  return (
+    <>
+      <div style={{ width: '100%', margin: '0.25em 0', textAlign: 'center', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+        <wired-input
+          id={id}
+          placeholder="http://localhost:3000"
+          style={{ width: '12em' }}
+          onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+            if (e.key === 'Enter') onConnect();
+          }}
+          onBlur={(e: React.FocusEvent<HTMLInputElement>) => {
+            const val = (e.target as HTMLInputElement).value || (e.target?.shadowRoot?.querySelector('input') as HTMLInputElement)?.value;
+            if (val) setCustomServer(val);
+          }}
+        ></wired-input>
+        <span style={{ cursor: 'pointer', fontSize: '1.5em', color: '#000', marginLeft: '0.25em' }} onClick={() => {
+          const input = document.getElementById(id) as HTMLInputElement;
+          const inner = input?.shadowRoot?.querySelector('input') as HTMLInputElement;
+          if (inner) inner.value = '';
+          if (input) input.value = '';
+          localStorage.removeItem('customServerUrl');
+        }}>×</span>
+      </div>
+      <div style={{ fontSize: '1em', margin: '0.5em 0', textAlign: 'center' }}>Custom servers are not managed by Blank White Cards. Connect at your own risk.</div>
+    </>
+  );
+}
+
 interface LobbyProps {
   globalSize: number;
   deckLoading: boolean;
@@ -143,6 +197,86 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
   const [stage, setStage] = useState('landing');
   const [joining, setJoining] = useState(false);
   const [preset, setPreset] = useState('blank');
+  const [connecting, setConnecting] = useState(false);
+
+  const connectCustomServer = useCallback(() => {
+    if (connecting) return;
+    setConnecting(true);
+    const input = document.getElementById('customServerCreateInput') as HTMLInputElement;
+    const val = (input?.shadowRoot?.querySelector('input') as HTMLInputElement)?.value || input?.value || getCustomServer();
+    resolveCustomServer(val).then((resolvedUrl) => {
+      setCustomServer(resolvedUrl);
+      const inner = input?.shadowRoot?.querySelector('input') as HTMLInputElement;
+      if (inner) inner.value = resolvedUrl;
+      else if (input) input.value = resolvedUrl;
+      return getLobbyClient('custom').listMatches('blank-white-cards');
+    }).then(() => {
+      setStage('create-deck');
+    }).catch(() => {
+      setConnecting(false);
+      requestAnimationFrame(() => {
+        const el = document.getElementById('customServerCreateInput') as HTMLElement;
+        if (el) {
+          el.style.color = 'red';
+          setTimeout(() => { el.style.color = ''; }, 1000);
+        }
+      });
+    }).finally(() => {
+      setConnecting(false);
+    });
+  }, [connecting]);
+
+  const connectJoinServer = useCallback(() => {
+    if (connecting) return;
+    const roomInput = document.getElementById('customServerRoomInput') as HTMLInputElement;
+    const urlInput = document.getElementById('customServerJoinInput') as HTMLInputElement;
+    const roomVal = ((roomInput?.shadowRoot?.querySelector('input') as HTMLInputElement)?.value || roomInput?.value || '').toUpperCase();
+    const urlVal = (urlInput?.shadowRoot?.querySelector('input') as HTMLInputElement)?.value || urlInput?.value || getCustomServer();
+
+    // Validate room code format
+    if (!roomVal.match(/^[BCDFGHJKLMNPQRSTVWXZ]{4}$/)) {
+      roomInput.style.color = 'red';
+      setTimeout(() => { roomInput.style.color = ''; }, 500);
+      return;
+    }
+
+    setConnecting(true);
+    resolveCustomServer(urlVal).then((resolvedUrl) => {
+      setCustomServer(resolvedUrl);
+      const inner = urlInput?.shadowRoot?.querySelector('input') as HTMLInputElement;
+      if (inner) inner.value = resolvedUrl;
+      else if (urlInput) urlInput.value = resolvedUrl;
+      setAuth({ ...auth, matchID: roomVal });
+      // First validate server is reachable, then look up the room
+      return getLobbyClient('custom').listMatches('blank-white-cards').then(() => {
+        return getLobbyClient('custom').getMatch('blank-white-cards', roomVal).then(() => {
+          setStage('join');
+        }).catch(() => {
+          // Server is reachable but room not found
+          setConnecting(false);
+          requestAnimationFrame(() => {
+            const room = document.getElementById('customServerRoomInput') as HTMLElement;
+            if (room) {
+              room.style.color = 'red';
+              setTimeout(() => { room.style.color = ''; }, 1000);
+            }
+          });
+        });
+      });
+    }).catch(() => {
+      // Server unreachable
+      setConnecting(false);
+      requestAnimationFrame(() => {
+        const el = document.getElementById('customServerJoinInput') as HTMLElement;
+        if (el) {
+          el.style.color = 'red';
+          setTimeout(() => { el.style.color = ''; }, 1000);
+        }
+      });
+    }).finally(() => {
+      setConnecting(false);
+    });
+  }, [connecting, auth, setAuth]);
 
   const enterSinglePlayer = () => {
     setAuth({});
@@ -295,8 +429,12 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
         setStage('landing');
       }
     }).catch(() => {
-      setStage('down');
-      setTimeout(checkLobbyConnection, 30000);
+      if (discordSdk) {
+        setStage('down');
+        setTimeout(checkLobbyConnection, 30000);
+      } else {
+        setStage('landing');
+      }
     });
   }, [setStage, checkForRoomCode]);
   useEffect(checkLobbyConnection, []);
@@ -332,8 +470,9 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
               </a>
             }
           </div>
+
           {stage === 'down' && (
-            <div style={{ ...styles.subheading, color: '#c00', fontSize: '0.85em' }}>Public servers unavailable — custom servers still work</div>
+            <div style={{ ...styles.subheading, fontSize: '0.85em' }}>Public servers unavailable</div>
           )}
 
           <div style={{ display: (stage == 'landing' || stage == 'down') ? undefined : 'none' }}>
@@ -367,46 +506,17 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
             }
             {!discordSdk && <wired-card style={{ ...styles.region, backgroundColor: (region == 'custom') ? '#eee' : undefined }} onClick={() => { setRegion('custom'); }}><Icon name="settings" />Custom</wired-card>}
             {region === 'custom' && (
-              <div style={{ width: '100%', margin: '0.25em 0', textAlign: 'center', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-                <wired-input
-                  id="customServerInput"
-                  placeholder="http://localhost:3000"
-                  style={{ width: '12em' }}
-                  onBlur={(e: React.FocusEvent<HTMLInputElement>) => {
-                    const val = (e.target as HTMLInputElement).value || (e.target?.shadowRoot?.querySelector('input') as HTMLInputElement)?.value;
-                    if (val) setCustomServer(val);
-                  }}
-                ></wired-input>
-                <span style={{ cursor: 'pointer', fontSize: '1.5em', color: '#000', marginLeft: '0.25em' }} onClick={() => {
-                  const input = document.getElementById('customServerInput') as HTMLInputElement;
-                  const inner = input?.shadowRoot?.querySelector('input') as HTMLInputElement;
-                  if (inner) inner.value = '';
-                  if (input) input.value = '';
-                }}>×</span>
-              </div>
+              <CustomServerInput id="customServerCreateInput" onConnect={connectCustomServer} autoFocus={region === 'custom' && stage === 'create-region'} />
             )}
             <div style={{ ...styles.presets }}>
               <wired-card style={styles.action} onClick={() => { roomCodeError(); setStage('landing') }}><Icon name="back" />Back</wired-card>
               <wired-card style={styles.action} onClick={() => {
                 if (region === 'custom') {
-                  // Save the URL and validate connectivity before proceeding
-                  const input = document.getElementById('customServerInput') as HTMLInputElement;
-                  const val = input?.value || input?.shadowRoot?.querySelector('input')?.value || getCustomServer();
-                  setCustomServer(val);
-                  getLobbyClient('custom').listMatches('blank-white-cards').then(() => {
-                    setStage('create-deck');
-                  }).catch(() => {
-                    // Flash the input red to indicate connection failure
-                    const el = document.getElementById('customServerInput') as HTMLElement;
-                    if (el) {
-                      el.style.color = 'red';
-                      setTimeout(() => { el.style.color = ''; }, 500);
-                    }
-                  });
+                  connectCustomServer();
                 } else {
                   setStage('create-deck');
                 }
-              }}><Icon name="done" />Confirm</wired-card>
+              }}>{connecting ? <div className="spin"><Icon name="loading" /></div> : <Icon name="done" />}Confirm</wired-card>
             </div>
           </div>
 
@@ -441,55 +551,20 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
 
           {/* Custom server prompt (join flow — TVWXZ room codes) */}
           <div style={{ ...styles.presets, display: (stage == 'custom-server') ? undefined : 'none' }}>
-            <div style={styles.subheading}>Custom Server</div>
-            <div style={styles.textentry}>
-              <wired-input style={styles.name} id="customServerJoinInput" placeholder="http://localhost:3000"></wired-input>
-              <span style={{ cursor: 'pointer', fontSize: '1.5em', color: '#000', marginLeft: '0.25em' }} onClick={() => {
-                const input = document.getElementById('customServerJoinInput') as HTMLInputElement;
-                const inner = input?.shadowRoot?.querySelector('input') as HTMLInputElement;
-                if (inner) inner.value = '';
-                if (input) input.value = '';
-              }}>×</span>
-            </div>
             <div style={styles.subheading}>Room Code</div>
             <div style={styles.textentry}>
-              <wired-input style={{ ...styles.code, fontSize: '1.5em' }} id="customServerRoomInput" placeholder="&nbsp;Room" maxlength={4} value={auth?.matchID} key={`room-${auth?.matchID}`}></wired-input>
+              <wired-input style={{ ...styles.code, fontSize: '1.5em', margin: 0 }} id="customServerRoomInput" placeholder="Room" maxlength={4} value={auth?.matchID} key={`room-${auth?.matchID}`} onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => { if (e.key === 'Enter') connectJoinServer(); }}></wired-input>
             </div>
+            <div style={styles.subheading}>Custom Server</div>
+            <CustomServerInput id="customServerJoinInput" onConnect={connectJoinServer} autoFocus={stage === 'custom-server'} />
             <div style={{ ...styles.presets }}>
               <wired-card style={styles.action} onClick={() => {
                 setAuth({});
                 setStage('landing');
               }}><Icon name="back" />Back</wired-card>
               <wired-card style={styles.action} onClick={() => {
-                const roomInput = document.getElementById('customServerRoomInput') as HTMLInputElement;
-                const urlInput = document.getElementById('customServerJoinInput') as HTMLInputElement;
-                const roomVal = (roomInput?.value || roomInput?.shadowRoot?.querySelector('input')?.value || '').toUpperCase();
-                const urlVal = urlInput?.value || urlInput?.shadowRoot?.querySelector('input')?.value || getCustomServer();
-
-                // Validate room code format
-                if (!roomVal.match(/^[BCDFGHJKLMNPQRSTVWXZ]{4}$/)) {
-                  roomInput.style.color = 'red';
-                  setTimeout(() => { roomInput.style.color = ''; }, 500);
-                  return;
-                }
-
-                setCustomServer(urlVal);
-                setAuth({ ...auth, matchID: roomVal });
-
-                // Try to connect and find the room
-                const lobbyClient = getLobbyClient('custom');
-                lobbyClient.getMatch('blank-white-cards', roomVal).then(async () => {
-                  setStage('join');
-                }).catch((err) => {
-                  if (err?.message?.includes('404') || err?.status === 404) {
-                    roomInput.style.color = 'red';
-                    setTimeout(() => { roomInput.style.color = ''; }, 500);
-                  } else {
-                    urlInput.style.color = 'red';
-                    setTimeout(() => { urlInput.style.color = ''; }, 500);
-                  }
-                });
-              }}><Icon name="play" />Connect</wired-card>
+                connectJoinServer();
+              }}>{connecting ? <div className="spin"><Icon name="loading" /></div> : <Icon name="play" />}Connect</wired-card>
             </div>
           </div>
 

--- a/app/src/Components/Lobby.tsx
+++ b/app/src/Components/Lobby.tsx
@@ -3,7 +3,7 @@ import { Properties } from 'csstype';
 import { Icon } from './Icons';
 import { useCallback, useContext, useEffect, useState } from "react";
 import { AuthContext, HotkeysContext } from "../lib/contexts";
-import { getLobbyClient, getRegion, getCustomServer, setCustomServer, resolveCustomServer } from "../lib/clients";
+import { getLobbyClient, getRegion, getCustomServer, setCustomServer, clearCustomServer, resolveCustomServer } from "../lib/clients";
 import type { Region } from "../lib/clients";
 import { externalLink } from "../lib/hooks";
 import { discordSdk } from "../lib/discord";
@@ -176,7 +176,7 @@ function CustomServerInput({ id, onConnect, autoFocus }: { id: string; onConnect
           const inner = input?.shadowRoot?.querySelector('input') as HTMLInputElement;
           if (inner) inner.value = '';
           if (input) input.value = '';
-          localStorage.removeItem('customServerUrl');
+          clearCustomServer();
         }}>×</span>
       </div>
       <div style={{ fontSize: '1em', margin: '0.5em 0', textAlign: 'center' }}>Custom servers are not managed by Blank White Cards. Connect at your own risk.</div>
@@ -213,7 +213,6 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
     }).then(() => {
       setStage('create-deck');
     }).catch(() => {
-      setConnecting(false);
       requestAnimationFrame(() => {
         const el = document.getElementById('customServerCreateInput') as HTMLElement;
         if (el) {
@@ -253,7 +252,6 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
           setStage('join');
         }).catch(() => {
           // Server is reachable but room not found
-          setConnecting(false);
           requestAnimationFrame(() => {
             const room = document.getElementById('customServerRoomInput') as HTMLElement;
             if (room) {
@@ -265,7 +263,6 @@ export function Lobby({ globalSize, deckLoading, region, setRegion }: LobbyProps
       });
     }).catch(() => {
       // Server unreachable
-      setConnecting(false);
       requestAnimationFrame(() => {
         const el = document.getElementById('customServerJoinInput') as HTMLElement;
         if (el) {

--- a/app/src/lib/clients.ts
+++ b/app/src/lib/clients.ts
@@ -130,6 +130,37 @@ export function setCustomServer(url: string): void {
   localStorage.setItem(CUSTOM_SERVER_KEY, url);
 }
 
+/**
+ * If the URL has no protocol, try https:// first, then fall back to http://.
+ * Always validates connectivity before returning.
+ * Returns the working URL or throws if the server is unreachable.
+ */
+export async function resolveCustomServer(input: string): Promise<string> {
+  const trimmed = input.trim();
+
+  // If protocol is already specified, trust it — LobbyClient will validate connectivity
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+
+  // Strip any accidental leading slashes
+  const bare = trimmed.replace(/^\/+/, '');
+
+  // Try https first — use no-cors since we just need to know the server is reachable
+  const httpsUrl = `https://${bare}`;
+  try {
+    await fetch(`${httpsUrl}/games`, { signal: AbortSignal.timeout(5000) });
+    return httpsUrl;
+  } catch (_) { /* fall through */ }
+
+  // Fall back to http
+  const httpUrl = `http://${bare}`;
+  try {
+    await fetch(`${httpUrl}/games`, { signal: AbortSignal.timeout(5000) });
+    return httpUrl;
+  } catch (_) { /* fall through */ }
+
+  throw new Error(`Could not connect to ${bare} over HTTPS or HTTP`);
+}
+
 export function getServerUrl(region: Region): string {
   if (region === 'custom') return getCustomServer();
   return SERVERS[region];

--- a/app/src/lib/clients.ts
+++ b/app/src/lib/clients.ts
@@ -130,6 +130,10 @@ export function setCustomServer(url: string): void {
   localStorage.setItem(CUSTOM_SERVER_KEY, url);
 }
 
+export function clearCustomServer(): void {
+  localStorage.removeItem(CUSTOM_SERVER_KEY);
+}
+
 /**
  * If the URL has no protocol, try https:// first, then fall back to http://.
  * Always validates connectivity before returning.

--- a/app/src/lib/hooks.ts
+++ b/app/src/lib/hooks.ts
@@ -55,7 +55,8 @@ export const useHotkeys = ({ hotkeys, setHotkeys}: HotkeysContextType) => {
     const keyDownHandler = (event: globalThis.KeyboardEvent) => {
       const tag = document.activeElement?.tagName?.toUpperCase();
       const isInputFocused = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'WIRED-INPUT' || tag === 'WIRED-TEXTAREA';
-      if (isInputFocused) return;
+      if (isInputFocused && event.code !== 'Enter' && event.code !== 'Escape') return;
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
       if (hotkeyMapping[event.code as keyof typeof hotkeyMapping]) {
         event.preventDefault();
         const hotkeyEvent: { [key: string]: boolean } = {};

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "pull:global": "npm run pull:global -w app",
     "serve": "npm run start -w server",
     "local": "npm run dev -w server",
-    "tunnel": "bash app/bin/tunnel.sh",
+    "tunnel": "bash server/bin/tunnel.sh",
     "serve:mcp": "npm run serve -w mcp",
     "local:mcp": "npm run dev -w mcp",
     "version:bump": "npm version patch --workspaces --include-workspace-root"

--- a/server/bin/tunnel.sh
+++ b/server/bin/tunnel.sh
@@ -11,7 +11,7 @@ fi
 
 # Read port from server env file, default to 3000
 PORT=3000
-ENV_FILE="$(dirname "$0")/../../server/.env.development"
+ENV_FILE="$(dirname "$0")/../.env.development"
 if [[ -f "$ENV_FILE" ]]; then
   PARSED_PORT=$(grep '^PORT=' "$ENV_FILE" | cut -d= -f2)
   [[ -n "$PARSED_PORT" ]] && PORT="$PARSED_PORT"


### PR DESCRIPTION
Quality of life improvements for the custom server connection UI.

## Changes

- **Protocol auto-resolution**: omit http/https and it tries https first, falls back to http
- **Shared CustomServerInput component**: deduplicated between create and join flows
- **Loading spinner**: shows on connect buttons during server validation
- **Enter key support**: on all custom server inputs
- **Disclaimer text**: "Custom servers are not managed by Blank White Cards. Connect at your own risk."
- **Auto-focus**: URL input focuses when custom server screen appears
- **Persist URL**: custom server URL cached in localStorage, pre-populated on return
- **Clear button**: also removes cached URL from localStorage
- **Error flash fix**: correct input flashes red (server URL vs room code)
- **Join flow reorder**: room code first, server URL second
- **Hotkey fixes**: skip all keys (except Enter/Escape) when input focused; skip when modifier keys held
- **Down state**: only shown in Discord Activity (browser goes straight to landing)
- **Tunnel script**: moved from app/bin to server/bin