### PR TITLE
feat: optional image compression in deck loader

### DIFF
--- a/app/src/Components/Loader.tsx
+++ b/app/src/Components/Loader.tsx
@@ -1,5 +1,5 @@
 import { Properties } from "csstype";
-import { useWindowDimensions } from "../lib/hooks";
+import { externalLink, useWindowDimensions } from "../lib/hooks";
 import { sanitiseCard } from "../lib/data";
 import { useCallback, useEffect, useReducer, useState } from "react";
 import { Card, getCardsByLocation } from "@mcteamster/white-core";
@@ -20,6 +20,8 @@ export function Loader({ moves, isMultiplayer, mode, setMode }: LoaderProps) {
   const [globalSubmit, setGlobalSubmit] = useState(false); // Global Submission Mode - Only one card can be uploaded
   const [loaded, setLoaded] = useState([] as Card[]); // List of cards staged for submitting
   const [progress, setProgress] = useState([-1, 0]); // Progress index of currently processing load: [currentIndex, endIndex]. -1 means no processing
+  const [compressImages, setCompressImages] = useState(true); // Whether to compress PNG images on load
+  const isCustomServer = !!localStorage.getItem('customServerUrl');
   const fileSelector = document.getElementById('fileselector') as HTMLInputElement;
 
   // Cache All Images from Imported Deck
@@ -86,7 +88,9 @@ export function Loader({ moves, isMultiplayer, mode, setMode }: LoaderProps) {
           deck.forEach(async (card: Card, i: number, arr: Card[]) => {
             if (card.content.image && card.content.image?.startsWith('data:image/png;base64,')) {
               dispatchImage({ id: i, value: card.content.image }) // Cache the Uncompressed Image
-              card.content.image = await compressImage(await resizeImage(card.content.image)); // Import Compressed image
+              if (compressImages) {
+                card.content.image = await compressImage(await resizeImage(card.content.image)); // Import Compressed image
+              }
             } else if (card.content.image) {
               // Cache the Decompressed Image
               decompressImage(card.content.image).then(res => {
@@ -124,7 +128,7 @@ export function Loader({ moves, isMultiplayer, mode, setMode }: LoaderProps) {
       setLoaded([]);
       setProgress([-1, 0])
     }
-  }, [fileSelector, globalSubmit])
+  }, [compressImages, fileSelector, globalSubmit])
 
   // Batch Submissions
   useEffect(() => {
@@ -319,11 +323,17 @@ export function Loader({ moves, isMultiplayer, mode, setMode }: LoaderProps) {
                     </div>)
                   })}
                 </div>
-                <div style={styles.prompt}>
-                  {globalSubmit ? 'Limited to ONE card per submission' : 'Tap cards to include/exclude'}
-                </div>
+                {globalSubmit ? (
+                  <div style={styles.prompt}>
+                    Limited to ONE card per submission
+                  </div>
+                ) : (
+                  <div style={styles.prompt}>
+                    Tap cards to include/exclude
+                  </div>
+                )}
               </wired-card> :
-              <div style={styles.instructionsContainer} >
+              <div id="fileCard" style={styles.instructionsContainer} >
                 {
                   !isMultiplayer ?
                   <>
@@ -331,15 +341,35 @@ export function Loader({ moves, isMultiplayer, mode, setMode }: LoaderProps) {
                       <Icon name='global' />
                       Submit a card to the Global Deck
                     </wired-card>
+                    <wired-card style={{...styles.instructions }} onClick={() => { externalLink('https://blankwhite.cards/editor') }}>
+                      <Icon name='create' />
+                      Open Deck Editor
+                    </wired-card>
                   </> :
-                  <wired-card style={{...styles.instructions }} onClick={() => { setGlobalSubmit(false); document.getElementById('fileselector')?.click() }}>
-                    <Icon name='display' />
-                    Load cards into this session
-                  </wired-card>
+                  <>
+                    <wired-card style={{...styles.instructions }} onClick={() => { setGlobalSubmit(false); document.getElementById('fileselector')?.click() }}>
+                      <Icon name='display' />
+                      Load cards into this session
+                    </wired-card>
+                    <wired-card style={{...styles.instructions }} onClick={() => { externalLink('https://blankwhite.cards/editor') }}>
+                      <Icon name='create' />
+                      Open Deck Editor
+                    </wired-card>
+                  </>
                 }
-                <div id="fileCard" style={styles.prompt}>
-                  From a Saved Deck File
-                </div>
+                {isCustomServer && isMultiplayer && (
+                  <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.25em', marginTop: '0.5em' }}>
+                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5em', cursor: 'pointer' }} onClick={() => setCompressImages(!compressImages)}>
+                      <span>Compress images</span>
+                      <wired-card style={{ height: '1em', width: '1em', fontWeight: 'bold', textAlign: 'center', display: 'flex', justifyContent: 'center', alignItems: 'center', backgroundColor: '#eee', borderRadius: '1em' }}>
+                        {compressImages && <Icon name="done" />}
+                      </wired-card>
+                    </div>
+                    {!compressImages && (
+                      <span style={{ color: 'red' }}>Not recommended for decks larger than 100 cards</span>
+                    )}
+                  </div>
+                )}
               </div>
           } 
           </div>
@@ -372,7 +402,7 @@ export function Loader({ moves, isMultiplayer, mode, setMode }: LoaderProps) {
         </div>
       </wired-dialog>
     )
-  }, [globalSubmit, height, imageCache, isMultiplayer, leaveLoader, loaded, mode, progress, setMode, uploadDeck, width])
+  }, [compressImages, globalSubmit, height, imageCache, isMultiplayer, leaveLoader, loaded, mode, progress, setMode, uploadDeck, width])
 
   return (displayLoader)
 }

--- a/app/src/Components/Loader.tsx
+++ b/app/src/Components/Loader.tsx
@@ -85,6 +85,9 @@ export function Loader({ moves, isMultiplayer, mode, setMode }: LoaderProps) {
           });
 
           // Process images for preview
+          // Note: forEach with async callbacks fires concurrently (not sequentially awaited).
+          // compressImages is captured from the closure at callback creation time, which is
+          // safe here because uploadDeck is re-created when compressImages changes (see dep array).
           deck.forEach(async (card: Card, i: number, arr: Card[]) => {
             if (card.content.image && card.content.image?.startsWith('data:image/png;base64,')) {
               dispatchImage({ id: i, value: card.content.image }) // Cache the Uncompressed Image
@@ -261,6 +264,34 @@ export function Loader({ moves, isMultiplayer, mode, setMode }: LoaderProps) {
         backgroundColor: '#eee',
         borderRadius: '1em',
       },
+      compressionOption: {
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: '0.25em',
+        marginTop: '0.5em',
+      },
+      compressionToggle: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '0.5em',
+        cursor: 'pointer',
+      },
+      checkbox: {
+        height: '1em',
+        width: '1em',
+        fontWeight: 'bold',
+        textAlign: 'center',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: '#eee',
+        borderRadius: '1em',
+      },
+      compressionWarning: {
+        color: 'red',
+      },
     }
 
       // Submit loaded cards to server
@@ -333,7 +364,7 @@ export function Loader({ moves, isMultiplayer, mode, setMode }: LoaderProps) {
                   </div>
                 )}
               </wired-card> :
-              <div id="fileCard" style={styles.instructionsContainer} >
+              <div style={styles.instructionsContainer} >
                 {
                   !isMultiplayer ?
                   <>
@@ -357,16 +388,24 @@ export function Loader({ moves, isMultiplayer, mode, setMode }: LoaderProps) {
                     </wired-card>
                   </>
                 }
+                <div id="fileCard" style={styles.prompt}>From a Saved Deck File</div>
                 {isCustomServer && isMultiplayer && (
-                  <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.25em', marginTop: '0.5em' }}>
-                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5em', cursor: 'pointer' }} onClick={() => setCompressImages(!compressImages)}>
+                  <div style={styles.compressionOption}>
+                    <div
+                      role="checkbox"
+                      aria-checked={compressImages}
+                      tabIndex={0}
+                      style={styles.compressionToggle}
+                      onClick={() => setCompressImages(!compressImages)}
+                      onKeyDown={(e) => { if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); setCompressImages(!compressImages) } }}
+                    >
                       <span>Compress images</span>
-                      <wired-card style={{ height: '1em', width: '1em', fontWeight: 'bold', textAlign: 'center', display: 'flex', justifyContent: 'center', alignItems: 'center', backgroundColor: '#eee', borderRadius: '1em' }}>
+                      <wired-card style={styles.checkbox}>
                         {compressImages && <Icon name="done" />}
                       </wired-card>
                     </div>
                     {!compressImages && (
-                      <span style={{ color: 'red' }}>Not recommended for decks larger than 100 cards</span>
+                      <span id="uploadWarning" style={styles.compressionWarning}>Not recommended for decks larger than 100 cards</span>
                     )}
                   </div>
                 )}

--- a/app/src/lib/clients.ts
+++ b/app/src/lib/clients.ts
@@ -153,14 +153,14 @@ export async function resolveCustomServer(input: string): Promise<string> {
   try {
     await fetch(`${httpsUrl}/games`, { signal: AbortSignal.timeout(5000) });
     return httpsUrl;
-  } catch (_) { /* fall through */ }
+  } catch { /* fall through */ }
 
   // Fall back to http
   const httpUrl = `http://${bare}`;
   try {
     await fetch(`${httpUrl}/games`, { signal: AbortSignal.timeout(5000) });
     return httpUrl;
-  } catch (_) { /* fall through */ }
+  } catch { /* fall through */ }
 
   throw new Error(`Could not connect to ${bare} over HTTPS or HTTP`);
 }
@@ -183,8 +183,8 @@ export function getLobbyClient(region: Region): LobbyClient {
   return lobbyClientCache.get(url)!;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 // TODO: boardgame.io Client() generic variance prevents proper typing here
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function getGameClient(region: Region): any {
   const url = getServerUrl(region);
   if (!gameClientCache.has(url)) {


### PR DESCRIPTION
## Summary

Add a "Compress images" checkbox to the Deck Loader, visible only on custom server multiplayer games. When unchecked, PNG data URI images are loaded into game state without 1-bit RLE compression, preserving full image fidelity.

## Changes

- **Loader.tsx**: Added `compressImages` state and `isCustomServer` detection
- Compression checkbox shown only on custom server + multiplayer sessions
- Gated existing `compressImage()` call behind the checkbox state
- Warning text when compression disabled: "Not recommended for decks larger than 100 cards"
- Added "Open Deck Editor" link in both singleplayer and multiplayer Loader views
- Removed redundant "From a Saved Deck File" label
- Restored "Tap cards to include/exclude" / "Limited to ONE card per submission" prompts

## Testing

- Custom server: checkbox visible, defaults to checked
- Public server: no checkbox, compression always applied
- Uncheck → load PNG deck → images stay as PNG data URIs in game state
- Already-compressed images pass through unchanged regardless