### PR TITLE
fix: remove height dependency from responsive font scaling

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -116,12 +116,12 @@ const App = () => {
   // Check Screen Size
   const dimensions = useWindowDimensions();
 
-  // Responsive: scale root font-size so all em/rem units adapt to viewport
+  // Responsive: scale root font-size so all em/rem units adapt to viewport width
   useEffect(() => {
-    const baseFontSize = Math.max(8, Math.min(16, Math.min(dimensions.width / 24, dimensions.height / 48)));
+    const baseFontSize = Math.max(8, Math.min(16, dimensions.width / 24));
     document.documentElement.style.fontSize = `${baseFontSize}px`;
     return () => { document.documentElement.style.fontSize = ''; };
-  }, [dimensions.width, dimensions.height]);
+  }, [dimensions.width]);
 
   // Check for In-App Browsers
   if (navigator.userAgent.match(/FBAN|FBAV|Instagram/i)) {


### PR DESCRIPTION
Removes the viewport height factor from the responsive font-size calculation. This prevents subtle font-size jitter when the mobile keyboard opens/closes or browser chrome hides/shows, since those only change innerHeight, not innerWidth.