### PR TITLE
feat: explicit host role with transfer and kick

### DIFF
--- a/app/src/Board.tsx
+++ b/app/src/Board.tsx
@@ -165,6 +165,44 @@ export function BlankWhiteCardsBoard(props: BoardProps<GameState>) {
   const myScore: number = (props.plugins as any)?.player?.data?.players?.[props.playerID || '0']?.score ?? 0;
   const playerName = props.matchData?.find(p => p.id === Number(props.playerID))?.name;
 
+  // Host transfer detection: when current host disconnects, elect new host
+  useEffect(() => {
+    if (!props.isMultiplayer || !props.matchData) return;
+    const hostID = props.G.hostPlayerID ?? '0';
+    const hostPlayer = props.matchData.find(p => p.id === Number(hostID));
+    // Only trigger if host is disconnected (or left entirely)
+    if (hostPlayer?.isConnected) return;
+
+    // Compute lowest eligible player: connected, named, not kicked
+    const eligible = props.matchData
+      .filter(p => p.isConnected && p.name && !props.G.kickedPlayers?.includes(String(p.id)))
+      .sort((a, b) => a.id - b.id);
+
+    if (eligible.length === 0) return;
+    const newHostID = String(eligible[0].id);
+    // Don't fire if already the host (no-op) or if we'd target current host
+    if (newHostID === hostID) return;
+
+    props.moves.transferHost(newHostID);
+  }, [props.isMultiplayer, props.matchData, props.G.hostPlayerID, props.G.kickedPlayers, props.moves]);
+
+  // Kick detection: if local player is kicked, disconnect and navigate away
+  const [kicked, setKicked] = useState(false);
+  useEffect(() => {
+    if (!props.isMultiplayer || !props.playerID) return;
+    if (props.G.kickedPlayers?.includes(props.playerID)) {
+      setKicked(true);
+    }
+  }, [props.isMultiplayer, props.playerID, props.G.kickedPlayers]);
+
+  useEffect(() => {
+    if (kicked) {
+      // Navigate to lobby — use window.location since we don't have router access here
+      alert('You were removed by the host.');
+      window.location.href = '/';
+    }
+  }, [kicked]);
+
   return (
     <ImageCacheContext.Provider value={{ imageCache, dispatchImage }}>
       <div style={boardStyle}>

--- a/app/src/Components/ActionSpace.tsx
+++ b/app/src/Components/ActionSpace.tsx
@@ -303,7 +303,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
         </>
       }
     } else if (G.cards.length == 0) {
-      if (playerID == '0') {
+      if (playerID == (G.hostPlayerID ?? '0')) {
         mainButtonContent = <>
           <Icon name='display' />
           Load Deck?
@@ -320,7 +320,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
         Reset Pile ({pile.length + discard.length})
       </>
     } else {
-      if (playerID == '0') {
+      if (playerID == (G.hostPlayerID ?? '0')) {
         mainButtonContent = <>
           <Icon name='shuffle' />
           Shuffle ALL ({G.cards.length})
@@ -339,7 +339,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
         if (deck.length > 0) {
           doPickup();
         } else if (G.cards.length == 0) {
-          if (playerID == '0') {
+          if (playerID == (G.hostPlayerID ?? '0')) {
             setMode('menu-tools-loader')
           } else {
             setMode('create-sketch')
@@ -347,7 +347,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
         } else if (pile.length + discard.length > 0) {
           doPickup();
         } else {
-          if (playerID == '0') {
+          if (playerID == (G.hostPlayerID ?? '0')) {
             setMode('menu-tools-reset')
           } else {
             setMode('create-sketch')

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -178,14 +178,27 @@ export function Players(props: PlayersProps) {
     }
   }
 
+  const isHost = props.playerID === (props.G.hostPlayerID ?? '0');
+
   const playerAvatars = props.matchData ? props.matchData.map((player, i) => {
     if (player.isConnected && player.name && player.id != Number(props.playerID)) { 
       const playerTable = getCardsByLocation(getCardsByOwner(props.G.cards, String(player.id)), 'table').sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0)); // Oldest to Newest
       const score = getPlayerScore(props.plugins, String(player.id));
+      const isPlayerHost = String(player.id) === (props.G.hostPlayerID ?? '0');
+      const isKicked = props.G.kickedPlayers?.includes(String(player.id));
+      if (isKicked) return undefined;
       
       return (
         <div key={`player-avatar-${i}`} style={styles.avatarBox}>
+          {isHost && !isPlayerHost && (
+            <span
+              style={{ cursor: 'pointer', fontSize: '1.2em', padding: '0 0.25em', color: '#c00' }}
+              title="Kick player"
+              onClick={(e) => { e.stopPropagation(); props.moves.forceLeave(String(player.id), props.matchData?.find(p => p.id === Number(props.playerID))?.name); }}
+            >×</span>
+          )}
           <wired-card style={styles.avatar} onClick={() => { if (playerTable.length > 0) { toggleOpenPlayers(player.id) }}}>
+            {isPlayerHost && <span title="Host" style={{ fontSize: '0.7em' }}>👑</span>}
             {(player.name).slice(0, 6)}{(player.name.length > 6) && '.'}
             <div style={styles.score}>
               <span
@@ -279,7 +292,7 @@ export function Header(props: HeaderProps) {
                 onCancel={() => setEditingMyScore(false)}
               />
             ) : (
-              <>{playerName}&nbsp;<span
+              <>{props.playerID === (props.G.hostPlayerID ?? '0') && <span title="Host">👑</span>}{playerName}&nbsp;<span
                 style={{ fontVariantNumeric: 'tabular-nums', cursor: 'pointer', textDecoration: 'underline dotted' }}
                 onClick={(e) => { e.stopPropagation(); setEditingMyScore(true); }}
               >{formatScore(myScore)} pts</span></>

--- a/app/src/Components/Console.tsx
+++ b/app/src/Components/Console.tsx
@@ -272,7 +272,7 @@ export function Console({ G, moves, playerID, playerName, plugins, matchData, op
                 {rules.map(rule => (
                   <div key={rule.id} style={styles.pinnedRule}>
                     <span style={styles.pinnedRuleText}>• {rule.text}</span>
-                    {(playerID === rule.playerID || playerID === '0') && (
+                    {(playerID === rule.playerID || playerID === (G.hostPlayerID ?? '0')) && (
                       <span style={styles.revokeBtn} onClick={() => moves.revokeRule(rule.id, playerName)}>×</span>
                     )}
                   </div>

--- a/core/src/Game.ts
+++ b/core/src/Game.ts
@@ -11,10 +11,13 @@ import { PluginGameLog } from "./lib/plugin-gamelog";
 export interface GameState {
   cards: Card[],
   rules?: Rule[],
+  hostPlayerID?: string,
+  kickedPlayers?: string[],
 }
 
 // Moves
 const pickupCard: Move<GameState> = ({ G, ctx, random, playerID, gamelog, chat }: any) => {
+  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
   const deck = getCardsByLocation(G.cards, "deck");
   if (deck.length === 0) {
     // Reshuffle Pile and Discard into Deck
@@ -52,6 +55,7 @@ const pickupCard: Move<GameState> = ({ G, ctx, random, playerID, gamelog, chat }
 }
 
 const moveCard: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, id, target, owner) => {
+  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
   const selectedCard = getCardById(G.cards, id);
   if (selectedCard) {
     const sourceLocation = selectedCard.location;
@@ -84,6 +88,7 @@ const moveCard: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, id,
 }
 
 const claimCard: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, id) => {
+  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
   const selectedCard = getCardById(G.cards, id);
   if (selectedCard) {
     if (selectedCard.location == 'pile') {
@@ -103,7 +108,8 @@ const claimCard: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, id
   }
 }
 
-const likeCard: Move<GameState> = ({ G }, id) => {
+const likeCard: Move<GameState> = ({ G, playerID }: any, id) => {
+  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
   const selectedCard = getCardById(G.cards, id);
   if (selectedCard?.likes) {
     selectedCard.likes++;
@@ -115,6 +121,7 @@ const likeCard: Move<GameState> = ({ G }, id) => {
 }
 
 const submitCard: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, card: Card, playerName?: string) => {
+  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
   card.id = G.cards.length + 1; // Commit ID sequentially to GameState
   G.cards.push(card);
   if (ctx.numPlayers > 1) {
@@ -124,7 +131,8 @@ const submitCard: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, c
 }
 
 const loadCards: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, cards: Card[]) => {
-  if(playerID !== '0') return INVALID_MOVE; // Only the host can bulk load cards
+  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
+  if(playerID !== (G.hostPlayerID ?? '0')) return INVALID_MOVE; // Only the host can bulk load cards
 
   // Bulk load batches of cards
   const loadBuffer: Card[] = [];
@@ -142,7 +150,8 @@ const loadCards: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, ca
 }
 
 const shuffleCards: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any) => {
-  if(playerID !== '0') return INVALID_MOVE; // Only the host can reset the game
+  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
+  if(playerID !== (G.hostPlayerID ?? '0')) return INVALID_MOVE; // Only the host can reset the game
 
   // Return all cards to the deck, except those in the box
   G.cards.forEach((card: Card) => { 
@@ -159,7 +168,8 @@ const shuffleCards: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any)
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const postMessage: Move<GameState> = ({ ctx, playerID, gamelog, chat }: any, text: string, playerName?: string) => {
+const postMessage: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, text: string, playerName?: string) => {
+  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
   if (ctx.numPlayers <= 1) return INVALID_MOVE;
   if (!text || text.length > 500) return INVALID_MOVE;
   gamelog.record({ move: 'postMessage', playerID, playerName, text: text.trim() });
@@ -168,6 +178,7 @@ const postMessage: Move<GameState> = ({ ctx, playerID, gamelog, chat }: any, tex
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const declareRule: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, text: string, playerName?: string) => {
+  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
   if (ctx.numPlayers <= 1) return INVALID_MOVE;
   if (!text || text.trim().length === 0 || text.length > 200) return INVALID_MOVE;
 
@@ -188,6 +199,7 @@ const declareRule: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, 
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const revokeRule: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, ruleId: number, playerName?: string) => {
+  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
   if (ctx.numPlayers <= 1) return INVALID_MOVE;
 
   const rules = G.rules ?? [];
@@ -195,7 +207,7 @@ const revokeRule: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, r
   if (ruleIndex === -1) return INVALID_MOVE;
 
   const rule = rules[ruleIndex];
-  if (playerID !== rule.playerID && playerID !== '0') return INVALID_MOVE;
+  if (playerID !== rule.playerID && playerID !== (G.hostPlayerID ?? '0')) return INVALID_MOVE;
 
   G.rules = rules.filter((r: Rule) => r.id !== ruleId);
 
@@ -204,7 +216,8 @@ const revokeRule: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, r
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const setScore: Move<GameState> = ({ ctx, player, gamelog, chat }: any, targetPlayerID: string, value: number, setterName?: string, targetName?: string) => {
+const setScore: Move<GameState> = ({ G, ctx, playerID, player, gamelog, chat }: any, targetPlayerID: string, value: number, setterName?: string, targetName?: string) => {
+  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
   if (player?.state && targetPlayerID in player.state) {
     const prev = player.state[targetPlayerID]?.score ?? 0;
     player.state[targetPlayerID] = { score: value };
@@ -218,6 +231,43 @@ const setScore: Move<GameState> = ({ ctx, player, gamelog, chat }: any, targetPl
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const transferHost: Move<GameState> = ({ G, playerID, gamelog, chat }: any, targetHostID: string) => {
+  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
+  if (targetHostID === (G.hostPlayerID ?? '0')) return INVALID_MOVE; // Already host
+  if (G.kickedPlayers?.includes(targetHostID)) return INVALID_MOVE; // Can't transfer to kicked
+
+  G.hostPlayerID = targetHostID;
+  gamelog.record({ move: 'transferHost', playerID, newHostID: targetHostID });
+  chat.syncFromLog(gamelog.entries());
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const forceLeave: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, targetPlayerID: string, playerName?: string) => {
+  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
+  if (playerID !== (G.hostPlayerID ?? '0')) return INVALID_MOVE; // Only host can kick
+  if (targetPlayerID === (G.hostPlayerID ?? '0')) return INVALID_MOVE; // Can't kick yourself
+  if (ctx.numPlayers <= 1) return INVALID_MOVE;
+
+  // Initialize kick list if needed
+  if (!G.kickedPlayers) G.kickedPlayers = [];
+  if (G.kickedPlayers.includes(targetPlayerID)) return INVALID_MOVE; // Already kicked
+
+  // Return target's hand and table cards to deck
+  G.cards.filter((c: Card) => c.owner === targetPlayerID).forEach((card: Card) => {
+    card.location = 'deck';
+    card.previousOwner = targetPlayerID;
+    card.owner = undefined;
+    card.timestamp = Number(Date.now());
+  });
+
+  // Mark as kicked
+  G.kickedPlayers.push(targetPlayerID);
+
+  gamelog.record({ move: 'forceLeave', playerID, targetPlayerID, playerName });
+  chat.syncFromLog(gamelog.entries());
+}
+
 // Game
 export const BlankWhiteCards: Game<GameState> = {
   name: 'blank-white-cards',
@@ -225,17 +275,17 @@ export const BlankWhiteCards: Game<GameState> = {
   setup: (_, setupData) => {
     const preset = (setupData?.presetDeck || 'blank') as string;
     if (preset == 'blank') {
-      return { cards: [], rules: [] }; // Blank White Deck
+      return { cards: [], rules: [], hostPlayerID: '0' }; // Blank White Deck
     } else {
       try {
         const deck = presetDecks[preset] // Look for a matching preset deck
         if (deck) {
-          return { ...deck, rules: deck.rules ?? [] };
+          return { ...deck, rules: deck.rules ?? [], hostPlayerID: '0' };
         }
       } catch (e) {
         console.error(e);
       }
-      return { cards: [], rules: [] }; // Blank White Deck as fallback
+      return { cards: [], rules: [], hostPlayerID: '0' }; // Blank White Deck as fallback
     }
   },
 
@@ -290,6 +340,16 @@ export const BlankWhiteCards: Game<GameState> = {
     },
     revokeRule: {
       move: revokeRule,
+      client: false,
+      ignoreStaleStateID: true,
+    },
+    transferHost: {
+      move: transferHost,
+      client: false,
+      ignoreStaleStateID: true,
+    },
+    forceLeave: {
+      move: forceLeave,
       client: false,
       ignoreStaleStateID: true,
     },

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -849,7 +849,7 @@ mcp.registerTool(
 mcp.registerTool(
   'revoke_rule',
   {
-    description: 'Revoke (remove) a house rule by its ID. Only the declaring player or the host (player 0) can revoke a rule.',
+    description: 'Revoke (remove) a house rule by its ID. Only the declaring player or the host can revoke a rule.',
     inputSchema: {
       matchID: z.string().describe('Room code'),
       playerID: z.string().describe('Your player ID'),
@@ -908,15 +908,17 @@ mcp.registerTool(
 mcp.registerTool(
   'shuffle_cards',
   {
-    description: 'Reset all cards back to the deck and shuffle (host / player 0 only)',
+    description: 'Reset all cards back to the deck and shuffle (host only)',
     inputSchema: {
       matchID: z.string().describe('Room code'),
-      playerID: z.string().describe('Your player ID (must be 0)'),
+      playerID: z.string().describe('Your player ID (must be host)'),
     },
   },
   async ({ matchID, playerID }) => {
-    if (playerID !== '0') throw new Error(`shuffle_cards is host-only (player 0). You are player ${playerID}.`);
     const { client } = requireSession(matchID, playerID);
+    const currentState = client.getState();
+    const hostID = (currentState?.G as any)?.hostPlayerID ?? '0';
+    if (playerID !== hostID) throw new Error(`shuffle_cards is host-only. You are player ${playerID}. The current host is player ${hostID}.`);
     const nextState = waitForMove(client);
     client.moves.shuffleCards();
     const state = await nextState;
@@ -927,10 +929,10 @@ mcp.registerTool(
 mcp.registerTool(
   'load_cards',
   {
-    description: 'Bulk load a set of cards into the match (host / player 0 only)',
+    description: 'Bulk load a set of cards into the match (host only)',
     inputSchema: {
       matchID: z.string().describe('Room code'),
-      playerID: z.string().describe('Your player ID (must be 0)'),
+      playerID: z.string().describe('Your player ID (must be host)'),
       cards: z.array(z.object({
         title: z.string(),
         description: z.string().optional(),
@@ -941,8 +943,10 @@ mcp.registerTool(
     },
   },
   async ({ matchID, playerID, cards }) => {
-    if (playerID !== '0') throw new Error(`load_cards is host-only (player 0). You are player ${playerID}.`);
     const { client } = requireSession(matchID, playerID);
+    const currentState = client.getState();
+    const hostID = (currentState?.G as any)?.hostPlayerID ?? '0';
+    if (playerID !== hostID) throw new Error(`load_cards is host-only. You are player ${playerID}. The current host is player ${hostID}.`);
     const cardObjects: Partial<Card>[] = await Promise.all(cards.map(async c => {
       let image: string | undefined;
       if (c.image_path) {


### PR DESCRIPTION
## Summary

Adds an explicit host player role to Blank White Cards multiplayer. The room creator (player 0) starts as host, and the role transfers automatically when the host disconnects.

## Changes

**Core (Game.ts):**
- `G.hostPlayerID` field in game state, initialized to `'0'`
- `G.kickedPlayers` array tracking removed players
- `transferHost` move — assigns new host (lowest connected player)
- `forceLeave` move — host can kick a player, returning their cards to deck
- All moves guarded against kicked players
- Host checks use `G.hostPlayerID` instead of hardcoded `'0'`

**Client:**
- Auto-detects host disconnect and triggers transfer
- Self-ejects when kicked (alert + redirect to lobby)
- Host badge (👑) in players panel and header
- Kick button (×) visible only to host
- Host-gated UI (load deck, shuffle) follows `hostPlayerID`

**MCP Server:**
- Dynamic host validation (reads `G.hostPlayerID` from state)
- Updated descriptions and error messages

## Testing

Verified with local multiplayer tests:
- Host transfer works (P0 → P1 → P0 round-trip)
- Kick works (cards return to deck, player blocked)
- Kicked players blocked from all moves
- Non-host rejected from host-only moves
- Backward compatible (games without `hostPlayerID` default to player 0)

Resolves BWC-16