### PR TITLE
refactor: move host/kicked state to PluginPlayer

### DIFF
--- a/app/src/Board.tsx
+++ b/app/src/Board.tsx
@@ -168,14 +168,16 @@ export function BlankWhiteCardsBoard(props: BoardProps<GameState>) {
   // Host transfer detection: when current host disconnects, elect new host
   useEffect(() => {
     if (!props.isMultiplayer || !props.matchData) return;
-    const hostID = props.G.hostPlayerID ?? '0';
+    const playerData = (props.plugins as any)?.player?.data;
+    const hostID = playerData?.hostPlayerID ?? '0';
+    const kickedPlayers: string[] = playerData?.kickedPlayers ?? [];
     const hostPlayer = props.matchData.find(p => p.id === Number(hostID));
     // Only trigger if host is disconnected (or left entirely)
     if (hostPlayer?.isConnected) return;
 
     // Compute lowest eligible player: connected, named, not kicked
     const eligible = props.matchData
-      .filter(p => p.isConnected && p.name && !props.G.kickedPlayers?.includes(String(p.id)))
+      .filter(p => p.isConnected && p.name && !kickedPlayers.includes(String(p.id)))
       .sort((a, b) => a.id - b.id);
 
     if (eligible.length === 0) return;
@@ -184,16 +186,17 @@ export function BlankWhiteCardsBoard(props: BoardProps<GameState>) {
     if (newHostID === hostID) return;
 
     props.moves.transferHost(newHostID);
-  }, [props.isMultiplayer, props.matchData, props.G.hostPlayerID, props.G.kickedPlayers, props.moves]);
+  }, [props.isMultiplayer, props.matchData, (props.plugins as any)?.player?.data?.hostPlayerID, (props.plugins as any)?.player?.data?.kickedPlayers, props.moves]);
 
   // Kick detection: if local player is kicked, disconnect and navigate away
   const [kicked, setKicked] = useState(false);
   useEffect(() => {
     if (!props.isMultiplayer || !props.playerID) return;
-    if (props.G.kickedPlayers?.includes(props.playerID)) {
+    const kickedPlayers: string[] = (props.plugins as any)?.player?.data?.kickedPlayers ?? [];
+    if (kickedPlayers.includes(props.playerID)) {
       setKicked(true);
     }
-  }, [props.isMultiplayer, props.playerID, props.G.kickedPlayers]);
+  }, [props.isMultiplayer, props.playerID, (props.plugins as any)?.player?.data?.kickedPlayers]);
 
   useEffect(() => {
     if (kicked) {
@@ -215,7 +218,7 @@ export function BlankWhiteCardsBoard(props: BoardProps<GameState>) {
         <Calculator
           initialValue={myScore}
           label={playerName}
-          onConfirm={(val) => { props.moves.setScore(props.playerID || '0', val, playerName, playerName); setScoreCalcOpen(false); }}
+          onConfirm={(val) => { if (val !== myScore) props.moves.setScore(props.playerID || '0', val, playerName, playerName); setScoreCalcOpen(false); }}
           onCancel={() => setScoreCalcOpen(false)}
         />
       )}

--- a/app/src/Board.tsx
+++ b/app/src/Board.tsx
@@ -7,7 +7,7 @@ import { CommonSpace } from './Components/CommonSpace.tsx';
 import { PlayerSpace } from './Components/PlayerSpace.tsx';
 import { Console } from './Components/Console.tsx';
 import { Calculator } from './Components/Calculator.tsx';
-import { useWindowDimensions } from './lib/hooks.ts';
+import { useWindowDimensions, usePlayerData } from './lib/hooks.ts';
 import { discordSdk } from './lib/discord.ts';
 
 // Web Components from https://wiredjs.com/
@@ -166,12 +166,10 @@ export function BlankWhiteCardsBoard(props: BoardProps<GameState>) {
   const playerName = props.matchData?.find(p => p.id === Number(props.playerID))?.name;
 
   // Host transfer detection: when current host disconnects, elect new host
+  const { hostPlayerID, kickedPlayers } = usePlayerData(props.plugins);
   useEffect(() => {
     if (!props.isMultiplayer || !props.matchData) return;
-    const playerData = (props.plugins as any)?.player?.data;
-    const hostID = playerData?.hostPlayerID ?? '0';
-    const kickedPlayers: string[] = playerData?.kickedPlayers ?? [];
-    const hostPlayer = props.matchData.find(p => p.id === Number(hostID));
+    const hostPlayer = props.matchData.find(p => p.id === Number(hostPlayerID));
     // Only trigger if host is disconnected (or left entirely)
     if (hostPlayer?.isConnected) return;
 
@@ -183,24 +181,26 @@ export function BlankWhiteCardsBoard(props: BoardProps<GameState>) {
     if (eligible.length === 0) return;
     const newHostID = String(eligible[0].id);
     // Don't fire if already the host (no-op) or if we'd target current host
-    if (newHostID === hostID) return;
+    if (newHostID === hostPlayerID) return;
 
     props.moves.transferHost(newHostID);
-  }, [props.isMultiplayer, props.matchData, (props.plugins as any)?.player?.data?.hostPlayerID, (props.plugins as any)?.player?.data?.kickedPlayers, props.moves]);
+  }, [props.isMultiplayer, props.matchData, hostPlayerID, kickedPlayers, props.moves]);
 
   // Kick detection: if local player is kicked, disconnect and navigate away
   const [kicked, setKicked] = useState(false);
   useEffect(() => {
     if (!props.isMultiplayer || !props.playerID) return;
-    const kickedPlayers: string[] = (props.plugins as any)?.player?.data?.kickedPlayers ?? [];
     if (kickedPlayers.includes(props.playerID)) {
       setKicked(true);
     }
-  }, [props.isMultiplayer, props.playerID, (props.plugins as any)?.player?.data?.kickedPlayers]);
+  }, [props.isMultiplayer, props.playerID, kickedPlayers]);
 
   useEffect(() => {
     if (kicked) {
-      // Navigate to lobby — use window.location since we don't have router access here
+      // Clear session so the player doesn't get redirected back to this match
+      localStorage.removeItem('matchID');
+      localStorage.removeItem('playerID');
+      localStorage.removeItem('credentials');
       alert('You were removed by the host.');
       window.location.href = '/';
     }

--- a/app/src/Components/ActionSpace.tsx
+++ b/app/src/Components/ActionSpace.tsx
@@ -15,7 +15,7 @@ import { Loader } from './Loader.tsx';
 import { submitGlobalCard } from '../lib/clients.ts';
 import { Tutorial } from './About.tsx';
 import { compressImage, resizeImage } from '../lib/images.ts';
-import { externalLink, useWindowDimensions } from '../lib/hooks.ts';
+import { externalLink, useWindowDimensions, usePlayerData } from '../lib/hooks.ts';
 import { discordSdk } from '../lib/discord';
 
 interface ToolbarProps extends BoardProps<GameState> {
@@ -28,6 +28,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
   const { setAuth } = useContext(AuthContext);
   const { loading, setLoading } = useContext(LoadingContext);
   const dimensions = useWindowDimensions();
+  const { hostPlayerID } = usePlayerData(plugins);
   const headerHeight = (discordSdk && dimensions.upright) ? '4.75em' : '2em';
   const [submitStatus, setSubmitStatus] = useState('Submit');
   const [drawMode, setDrawMode] = useState<string>(MODE_DRAW);
@@ -303,7 +304,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
         </>
       }
     } else if (G.cards.length == 0) {
-      if (playerID == ((plugins as any)?.player?.data?.hostPlayerID ?? '0')) {
+      if (playerID == hostPlayerID) {
         mainButtonContent = <>
           <Icon name='display' />
           Load Deck?
@@ -320,7 +321,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
         Reset Pile ({pile.length + discard.length})
       </>
     } else {
-      if (playerID == ((plugins as any)?.player?.data?.hostPlayerID ?? '0')) {
+      if (playerID == hostPlayerID) {
         mainButtonContent = <>
           <Icon name='shuffle' />
           Shuffle ALL ({G.cards.length})
@@ -339,7 +340,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
         if (deck.length > 0) {
           doPickup();
         } else if (G.cards.length == 0) {
-          if (playerID == ((plugins as any)?.player?.data?.hostPlayerID ?? '0')) {
+          if (playerID == hostPlayerID) {
             setMode('menu-tools-loader')
           } else {
             setMode('create-sketch')
@@ -347,7 +348,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
         } else if (pile.length + discard.length > 0) {
           doPickup();
         } else {
-          if (playerID == ((plugins as any)?.player?.data?.hostPlayerID ?? '0')) {
+          if (playerID == hostPlayerID) {
             setMode('menu-tools-reset')
           } else {
             setMode('create-sketch')

--- a/app/src/Components/ActionSpace.tsx
+++ b/app/src/Components/ActionSpace.tsx
@@ -23,7 +23,7 @@ interface ToolbarProps extends BoardProps<GameState> {
   setMode: React.Dispatch<React.SetStateAction<string>>;
 }
 
-export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID, mode, setMode, ctx }: ToolbarProps) {
+export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID, mode, setMode, ctx, plugins }: ToolbarProps) {
   const navigate = useNavigate();
   const { setAuth } = useContext(AuthContext);
   const { loading, setLoading } = useContext(LoadingContext);
@@ -303,7 +303,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
         </>
       }
     } else if (G.cards.length == 0) {
-      if (playerID == (G.hostPlayerID ?? '0')) {
+      if (playerID == ((plugins as any)?.player?.data?.hostPlayerID ?? '0')) {
         mainButtonContent = <>
           <Icon name='display' />
           Load Deck?
@@ -320,7 +320,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
         Reset Pile ({pile.length + discard.length})
       </>
     } else {
-      if (playerID == (G.hostPlayerID ?? '0')) {
+      if (playerID == ((plugins as any)?.player?.data?.hostPlayerID ?? '0')) {
         mainButtonContent = <>
           <Icon name='shuffle' />
           Shuffle ALL ({G.cards.length})
@@ -339,7 +339,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
         if (deck.length > 0) {
           doPickup();
         } else if (G.cards.length == 0) {
-          if (playerID == (G.hostPlayerID ?? '0')) {
+          if (playerID == ((plugins as any)?.player?.data?.hostPlayerID ?? '0')) {
             setMode('menu-tools-loader')
           } else {
             setMode('create-sketch')
@@ -347,7 +347,7 @@ export function Toolbar({ G, playerID, moves, isMultiplayer, matchData, matchID,
         } else if (pile.length + discard.length > 0) {
           doPickup();
         } else {
-          if (playerID == (G.hostPlayerID ?? '0')) {
+          if (playerID == ((plugins as any)?.player?.data?.hostPlayerID ?? '0')) {
             setMode('menu-tools-reset')
           } else {
             setMode('create-sketch')

--- a/app/src/Components/Calculator.tsx
+++ b/app/src/Components/Calculator.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import type { CSSProperties } from 'react';
 import { Icon } from './Icons';
 
@@ -186,56 +187,69 @@ export function Calculator({ initialValue, onConfirm, onCancel, label }: Calcula
   const confirmBtn: CSSProperties = { ...base, backgroundColor: '#ccc' };
   const cancelBtn: CSSProperties = { ...base, backgroundColor: '#ccc', color: '#c00' };
 
-  return (
-    <wired-dialog open onClick={sp}>
-      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0, padding: '0.5em 0.75em 0.75em' }}>
-        {/* Display */}
-        <wired-card style={{ width: '17em', margin: '0.5em 0', cursor: 'default', position: 'relative' } as CSSProperties}
-          onClick={(e) => e.stopPropagation()}
-        >
-          {label && <span style={{ position: 'absolute', top: '0em', left: '0.3em', fontSize: '0.8em', color: '#888' }}>{label}</span>}
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', fontFamily: 'monospace', fontSize: '1.5em', minHeight: '2.25em', padding: '0 0.25em' }}>
-            <span style={{ textAlign: 'right', maxWidth: '15em', overflowX: 'hidden' }}>{expr}</span>
+  const overlay: CSSProperties = {
+    position: 'fixed',
+    inset: 0,
+    zIndex: 100,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.4)',
+  };
+
+  return createPortal(
+    <div style={overlay} onClick={sp}>
+      <wired-card style={{ padding: '0', cursor: 'default', backgroundColor: 'white' } as CSSProperties} onClick={sp}>
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0, padding: '0.5em 0.75em 0.75em' }}>
+          {/* Display */}
+          <wired-card style={{ width: '17em', margin: '0.5em 0', cursor: 'default', position: 'relative' } as CSSProperties}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {label && <span style={{ position: 'absolute', top: '0em', left: '0.3em', fontSize: '0.8em', color: '#888' }}>{label}</span>}
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', fontFamily: 'monospace', fontSize: '1.5em', minHeight: '2.25em', padding: '0 0.25em' }}>
+              <span style={{ textAlign: 'right', maxWidth: '15em', overflowX: 'hidden' }}>{expr}</span>
+            </div>
+          </wired-card>
+          {/* Row 1: ⌫ | C | ^ | ÷ */}
+          <div style={{ display: 'flex' }}>
+            <wired-card style={btn} onClick={() => backspace()}>⌫</wired-card>
+            <wired-card style={btn} onClick={() => clear()}>C</wired-card>
+            <wired-card style={btn} onClick={() => append('^')}>^</wired-card>
+            <wired-card style={btn} onClick={() => append('÷')}>÷</wired-card>
           </div>
-        </wired-card>
-        {/* Row 1: ⌫ | C | ^ | ÷ */}
-        <div style={{ display: 'flex' }}>
-          <wired-card style={btn} onClick={() => backspace()}>⌫</wired-card>
-          <wired-card style={btn} onClick={() => clear()}>C</wired-card>
-          <wired-card style={btn} onClick={() => append('^')}>^</wired-card>
-          <wired-card style={btn} onClick={() => append('÷')}>÷</wired-card>
+          {/* Row 2: 7 8 9 × */}
+          <div style={{ display: 'flex' }}>
+            {['7','8','9'].map(k => <wired-card key={k} style={btn} onClick={() => append(k)}>{k}</wired-card>)}
+            <wired-card style={btn} onClick={() => append('×')}>×</wired-card>
+          </div>
+          {/* Row 3: 4 5 6 − */}
+          <div style={{ display: 'flex' }}>
+            {['4','5','6'].map(k => <wired-card key={k} style={btn} onClick={() => append(k)}>{k}</wired-card>)}
+            <wired-card style={btn} onClick={() => append('−')}>−</wired-card>
+          </div>
+          {/* Row 4: 1 2 3 + */}
+          <div style={{ display: 'flex' }}>
+            {['1','2','3'].map(k => <wired-card key={k} style={btn} onClick={() => append(k)}>{k}</wired-card>)}
+            <wired-card style={btn} onClick={() => append('+')}>+</wired-card>
+          </div>
+          {/* Row 5: . | 0 | = (wide) */}
+          <div style={{ display: 'flex', width: '100%' }}>
+            <wired-card style={btn} onClick={() => append('.')}>.</wired-card>
+            <wired-card style={btn} onClick={() => append('0')}>0</wired-card>
+            <wired-card style={{ ...btn, flex: 1 }} onClick={() => evaluate()}>=</wired-card>
+          </div>
+          {/* Row 6: Cancel (half) | Done (half) */}
+          <div style={{ display: 'flex', width: '100%', gap: 0 }}>
+            <wired-card style={{ ...cancelBtn, flex: 1 }} onClick={() => onCancel()}>
+              <Icon name='exit' />
+            </wired-card>
+            <wired-card style={{ ...confirmBtn, flex: 1 }} onClick={() => { if (valid) onConfirm(parsed!); }}>
+              <Icon name='done' />
+            </wired-card>
+          </div>
         </div>
-        {/* Row 2: 7 8 9 × */}
-        <div style={{ display: 'flex' }}>
-          {['7','8','9'].map(k => <wired-card key={k} style={btn} onClick={() => append(k)}>{k}</wired-card>)}
-          <wired-card style={btn} onClick={() => append('×')}>×</wired-card>
-        </div>
-        {/* Row 3: 4 5 6 − */}
-        <div style={{ display: 'flex' }}>
-          {['4','5','6'].map(k => <wired-card key={k} style={btn} onClick={() => append(k)}>{k}</wired-card>)}
-          <wired-card style={btn} onClick={() => append('−')}>−</wired-card>
-        </div>
-        {/* Row 4: 1 2 3 + */}
-        <div style={{ display: 'flex' }}>
-          {['1','2','3'].map(k => <wired-card key={k} style={btn} onClick={() => append(k)}>{k}</wired-card>)}
-          <wired-card style={btn} onClick={() => append('+')}>+</wired-card>
-        </div>
-        {/* Row 5: . | 0 | = (wide) */}
-        <div style={{ display: 'flex', width: '100%' }}>
-          <wired-card style={btn} onClick={() => append('.')}>.</wired-card>
-          <wired-card style={btn} onClick={() => append('0')}>0</wired-card>
-          <wired-card style={{ ...btn, flex: 1 }} onClick={() => evaluate()}>=</wired-card>
-        </div>
-        {/* Row 6: Cancel (half) | Done (half) */}
-        <div style={{ display: 'flex', width: '100%', gap: 0 }}>
-          <wired-card style={{ ...cancelBtn, flex: 1 }} onClick={() => onCancel()}>
-            <Icon name='exit' />
-          </wired-card>
-          <wired-card style={{ ...confirmBtn, flex: 1 }} onClick={() => { if (valid) onConfirm(parsed!); }}>
-            <Icon name='done' />
-          </wired-card>
-        </div>
-      </div>
-    </wired-dialog>
+      </wired-card>
+    </div>,
+    document.body
   );
 }

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -6,7 +6,7 @@ import { CardFace } from './CardFace.tsx';
 import { getCardsByLocation, getCardsByOwner } from '@mcteamster/white-core';
 import { Icon } from './Icons';
 import { useCallback, useContext, useEffect, useState } from 'react';
-import { useWindowDimensions } from '../lib/hooks.ts';
+import { useWindowDimensions, usePlayerData } from '../lib/hooks.ts';
 import { FocusContext } from '../lib/contexts.ts';
 import { discordSdk } from '../lib/discord.ts';
 import { Likes } from './Focus.tsx';
@@ -178,14 +178,15 @@ export function Players(props: PlayersProps) {
     }
   }
 
-  const isHost = props.playerID === ((props.plugins as any)?.player?.data?.hostPlayerID ?? '0');
+  const { hostPlayerID, kickedPlayers } = usePlayerData(props.plugins);
+  const isHost = props.playerID === hostPlayerID;
 
   const playerAvatars = props.matchData ? props.matchData.map((player, i) => {
     if (player.isConnected && player.name && player.id != Number(props.playerID)) { 
       const playerTable = getCardsByLocation(getCardsByOwner(props.G.cards, String(player.id)), 'table').sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0)); // Oldest to Newest
       const score = getPlayerScore(props.plugins, String(player.id));
-      const isPlayerHost = String(player.id) === ((props.plugins as any)?.player?.data?.hostPlayerID ?? '0');
-      const isKicked = ((props.plugins as any)?.player?.data?.kickedPlayers ?? []).includes(String(player.id));
+      const isPlayerHost = String(player.id) === hostPlayerID;
+      const isKicked = kickedPlayers.includes(String(player.id));
       if (isKicked) return undefined;
       
       return (
@@ -250,6 +251,7 @@ export function Header(props: HeaderProps) {
   const [showShare, setShowShare] = useState(false);
   const [editingMyScore, setEditingMyScore] = useState(false);
   const dimensions = useWindowDimensions();
+  const { hostPlayerID: headerHostID } = usePlayerData(props.plugins);
 
   const playerName = props.isMultiplayer && props.matchData?.find((player) => player.id == Number(props.playerID))?.name?.toUpperCase() || ""
   const myScore = getPlayerScore(props.plugins, props.playerID || '0');
@@ -293,7 +295,7 @@ export function Header(props: HeaderProps) {
                 onCancel={() => setEditingMyScore(false)}
               />
             ) : (
-              <>{props.playerID === ((props.plugins as any)?.player?.data?.hostPlayerID ?? '0') && <span title="Host" style={{ display: 'inline-flex', verticalAlign: 'middle' }}><Icon name='special' /></span>}{playerName}&nbsp;<span
+              <>{props.playerID === headerHostID && <span title="Host" style={{ display: 'inline-flex', verticalAlign: 'middle' }}><Icon name='special' /></span>}{playerName}&nbsp;<span
                 style={{ fontVariantNumeric: 'tabular-nums', cursor: 'pointer', textDecoration: 'underline dotted' }}
                 onClick={(e) => { e.stopPropagation(); setEditingMyScore(true); }}
               >{formatScore(myScore)} pts</span></>

--- a/app/src/Components/CommonSpace.tsx
+++ b/app/src/Components/CommonSpace.tsx
@@ -178,35 +178,36 @@ export function Players(props: PlayersProps) {
     }
   }
 
-  const isHost = props.playerID === (props.G.hostPlayerID ?? '0');
+  const isHost = props.playerID === ((props.plugins as any)?.player?.data?.hostPlayerID ?? '0');
 
   const playerAvatars = props.matchData ? props.matchData.map((player, i) => {
     if (player.isConnected && player.name && player.id != Number(props.playerID)) { 
       const playerTable = getCardsByLocation(getCardsByOwner(props.G.cards, String(player.id)), 'table').sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0)); // Oldest to Newest
       const score = getPlayerScore(props.plugins, String(player.id));
-      const isPlayerHost = String(player.id) === (props.G.hostPlayerID ?? '0');
-      const isKicked = props.G.kickedPlayers?.includes(String(player.id));
+      const isPlayerHost = String(player.id) === ((props.plugins as any)?.player?.data?.hostPlayerID ?? '0');
+      const isKicked = ((props.plugins as any)?.player?.data?.kickedPlayers ?? []).includes(String(player.id));
       if (isKicked) return undefined;
       
       return (
         <div key={`player-avatar-${i}`} style={styles.avatarBox}>
-          {isHost && !isPlayerHost && (
-            <span
-              style={{ cursor: 'pointer', fontSize: '1.2em', padding: '0 0.25em', color: '#c00' }}
-              title="Kick player"
-              onClick={(e) => { e.stopPropagation(); props.moves.forceLeave(String(player.id), props.matchData?.find(p => p.id === Number(props.playerID))?.name); }}
-            >×</span>
-          )}
-          <wired-card style={styles.avatar} onClick={() => { if (playerTable.length > 0) { toggleOpenPlayers(player.id) }}}>
-            {isPlayerHost && <span title="Host" style={{ fontSize: '0.7em' }}>👑</span>}
-            {(player.name).slice(0, 6)}{(player.name.length > 6) && '.'}
-            <div style={styles.score}>
+          <div style={{ position: 'relative', display: 'inline-block' }}>
+            {isHost && !isPlayerHost && (
               <span
-                style={{ cursor: 'pointer', textDecoration: 'underline dotted' }}
-                onClick={(e) => { e.stopPropagation(); setEditingScore(player.id); }}
-              >{formatScore(score)}</span>
-            </div>
-          </wired-card>
+                style={{ position: 'absolute', top: '0.7em', right: '0.7em', cursor: 'pointer', fontSize: '14px', color: '#000', lineHeight: 1, zIndex: 1 }}
+                title="Kick player"
+                onClick={(e) => { e.stopPropagation(); props.moves.forceLeave(String(player.id), props.matchData?.find(p => p.id === Number(props.playerID))?.name); }}
+              >×</span>
+            )}
+            <wired-card style={styles.avatar} onClick={() => { if (playerTable.length > 0) { toggleOpenPlayers(player.id) }}}>
+              {(player.name).slice(0, 6)}{(player.name.length > 6) && '.'}
+              <div style={styles.score}>
+                <span
+                  style={{ cursor: 'pointer', textDecoration: 'underline dotted' }}
+                  onClick={(e) => { e.stopPropagation(); setEditingScore(player.id); }}
+                >{formatScore(score)}</span>
+              </div>
+            </wired-card>
+          </div>
           {(playerTable.length > 0) && <span style={styles.stats}>{(!openPlayers.includes(player.id)) ? '<' : '>'}</span>}
           {
             openPlayers.includes(player.id) &&
@@ -231,7 +232,7 @@ export function Players(props: PlayersProps) {
         <Calculator
           initialValue={getPlayerScore(props.plugins, String(editingScore))}
           label={props.matchData?.find(p => p.id === editingScore)?.name}
-          onConfirm={(val) => { props.moves.setScore(String(editingScore), val, props.matchData?.find(p => p.id === Number(props.playerID))?.name, props.matchData?.find(p => p.id === editingScore)?.name); setEditingScore(null); }}
+          onConfirm={(val) => { if (val !== getPlayerScore(props.plugins, String(editingScore))) props.moves.setScore(String(editingScore), val, props.matchData?.find(p => p.id === Number(props.playerID))?.name, props.matchData?.find(p => p.id === editingScore)?.name); setEditingScore(null); }}
           onCancel={() => setEditingScore(null)}
         />
       )}
@@ -288,11 +289,11 @@ export function Header(props: HeaderProps) {
               <Calculator
                 initialValue={myScore}
                 label={playerName || undefined}
-                onConfirm={(val) => { props.moves.setScore(props.playerID || '0', val, playerName, playerName); setEditingMyScore(false); }}
+                onConfirm={(val) => { if (val !== myScore) props.moves.setScore(props.playerID || '0', val, playerName, playerName); setEditingMyScore(false); }}
                 onCancel={() => setEditingMyScore(false)}
               />
             ) : (
-              <>{props.playerID === (props.G.hostPlayerID ?? '0') && <span title="Host">👑</span>}{playerName}&nbsp;<span
+              <>{props.playerID === ((props.plugins as any)?.player?.data?.hostPlayerID ?? '0') && <span title="Host" style={{ display: 'inline-flex', verticalAlign: 'middle' }}><Icon name='special' /></span>}{playerName}&nbsp;<span
                 style={{ fontVariantNumeric: 'tabular-nums', cursor: 'pointer', textDecoration: 'underline dotted' }}
                 onClick={(e) => { e.stopPropagation(); setEditingMyScore(true); }}
               >{formatScore(myScore)} pts</span></>

--- a/app/src/Components/Console.tsx
+++ b/app/src/Components/Console.tsx
@@ -4,7 +4,7 @@ import type { Properties } from 'csstype';
 import { useEffect, useRef, useState } from 'react';
 import { Icon } from './Icons';
 import { discordSdk } from '../lib/discord';
-import { useWindowDimensions } from '../lib/hooks';
+import { useWindowDimensions, usePlayerData } from '../lib/hooks';
 
 interface ConsoleProps extends BoardProps<GameState> {
   playerName?: string;
@@ -17,6 +17,7 @@ export function Console({ G, moves, playerID, playerName, plugins, matchData, op
   const messages: Message[] = (plugins as any)?.chat?.data?.messages ?? [];
   const rules: Rule[] = G?.rules ?? [];
   const dimensions = useWindowDimensions();
+  const { hostPlayerID } = usePlayerData(plugins);
   const headerHeight = (discordSdk && dimensions.upright) ? '4.75em' : '2em';
   const [localOpen, setLocalOpen] = useState(false);
   const open = openProp ?? localOpen;
@@ -272,7 +273,7 @@ export function Console({ G, moves, playerID, playerName, plugins, matchData, op
                 {rules.map(rule => (
                   <div key={rule.id} style={styles.pinnedRule}>
                     <span style={styles.pinnedRuleText}>• {rule.text}</span>
-                    {(playerID === rule.playerID || playerID === ((plugins as any)?.player?.data?.hostPlayerID ?? '0')) && (
+                    {(playerID === rule.playerID || playerID === hostPlayerID) && (
                       <span style={styles.revokeBtn} onClick={() => moves.revokeRule(rule.id, playerName)}>×</span>
                     )}
                   </div>

--- a/app/src/Components/Console.tsx
+++ b/app/src/Components/Console.tsx
@@ -272,7 +272,7 @@ export function Console({ G, moves, playerID, playerName, plugins, matchData, op
                 {rules.map(rule => (
                   <div key={rule.id} style={styles.pinnedRule}>
                     <span style={styles.pinnedRuleText}>• {rule.text}</span>
-                    {(playerID === rule.playerID || playerID === (G.hostPlayerID ?? '0')) && (
+                    {(playerID === rule.playerID || playerID === ((plugins as any)?.player?.data?.hostPlayerID ?? '0')) && (
                       <span style={styles.revokeBtn} onClick={() => moves.revokeRule(rule.id, playerName)}>×</span>
                     )}
                   </div>

--- a/app/src/Components/Icons.tsx
+++ b/app/src/Components/Icons.tsx
@@ -38,6 +38,7 @@ import RecyclingIcon from '@mui/icons-material/Recycling';
 import SaveAltOutlinedIcon from '@mui/icons-material/SaveAltOutlined';
 import ScreenRotationOutlinedIcon from '@mui/icons-material/ScreenRotationOutlined';
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined';
+import StarOutlinedIcon from '@mui/icons-material/StarOutlined';
 import SportsEsportsOutlinedIcon from '@mui/icons-material/SportsEsportsOutlined';
 import SyncOutlinedIcon from '@mui/icons-material/SyncOutlined';
 import UndoOutlinedIcon from '@mui/icons-material/UndoOutlined';
@@ -94,6 +95,7 @@ type IconName =
   'view_module' |
   'show' |
   'hide' |
+  'special' |
   'solid' |
   'stipple' |
   'wand' |
@@ -148,6 +150,7 @@ export function Icon(props: { name: IconName }) {
     stop: <StopIcon></StopIcon>,
     show: <VisibilityIcon></VisibilityIcon>,
     hide: <VisibilityOffIcon></VisibilityOffIcon>,
+    special: <StarOutlinedIcon></StarOutlinedIcon>,
     solid: <StopIcon></StopIcon>,
     stipple: <GrainIcon></GrainIcon>,
     wand: <AutoFixHighIcon></AutoFixHighIcon>,

--- a/app/src/lib/hooks.ts
+++ b/app/src/lib/hooks.ts
@@ -1,7 +1,17 @@
 // Hooks
-import { useState, useEffect, useRef } from 'react';
+import { useMemo, useState, useEffect, useRef } from 'react';
 import { HotkeysContextType } from './contexts';
 import { discordSdk } from './discord';
+
+// Plugin Player Data
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function usePlayerData(plugins: any) {
+  const data = plugins?.player?.data;
+  return useMemo(() => ({
+    hostPlayerID: (data?.hostPlayerID ?? '0') as string,
+    kickedPlayers: (data?.kickedPlayers ?? []) as string[],
+  }), [data?.hostPlayerID, data?.kickedPlayers]);
+}
 
 // Dimensions
 const getWindowDimensions = () => {

--- a/core/src/Game.ts
+++ b/core/src/Game.ts
@@ -11,13 +11,11 @@ import { PluginGameLog } from "./lib/plugin-gamelog";
 export interface GameState {
   cards: Card[],
   rules?: Rule[],
-  hostPlayerID?: string,
-  kickedPlayers?: string[],
 }
 
 // Moves
-const pickupCard: Move<GameState> = ({ G, ctx, random, playerID, gamelog, chat }: any) => {
-  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
+const pickupCard: Move<GameState> = ({ G, ctx, random, playerID, player, gamelog, chat }: any) => {
+  if (player.isKicked(playerID)) return INVALID_MOVE;
   const deck = getCardsByLocation(G.cards, "deck");
   if (deck.length === 0) {
     // Reshuffle Pile and Discard into Deck
@@ -54,8 +52,8 @@ const pickupCard: Move<GameState> = ({ G, ctx, random, playerID, gamelog, chat }
   }
 }
 
-const moveCard: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, id, target, owner) => {
-  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
+const moveCard: Move<GameState> = ({ G, ctx, playerID, player, gamelog, chat }: any, id, target, owner) => {
+  if (player.isKicked(playerID)) return INVALID_MOVE;
   const selectedCard = getCardById(G.cards, id);
   if (selectedCard) {
     const sourceLocation = selectedCard.location;
@@ -87,8 +85,8 @@ const moveCard: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, id,
   }
 }
 
-const claimCard: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, id) => {
-  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
+const claimCard: Move<GameState> = ({ G, ctx, playerID, player, gamelog, chat }: any, id) => {
+  if (player.isKicked(playerID)) return INVALID_MOVE;
   const selectedCard = getCardById(G.cards, id);
   if (selectedCard) {
     if (selectedCard.location == 'pile') {
@@ -108,8 +106,8 @@ const claimCard: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, id
   }
 }
 
-const likeCard: Move<GameState> = ({ G, playerID }: any, id) => {
-  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
+const likeCard: Move<GameState> = ({ G, playerID, player }: any, id) => {
+  if (player.isKicked(playerID)) return INVALID_MOVE;
   const selectedCard = getCardById(G.cards, id);
   if (selectedCard?.likes) {
     selectedCard.likes++;
@@ -120,8 +118,8 @@ const likeCard: Move<GameState> = ({ G, playerID }: any, id) => {
   }
 }
 
-const submitCard: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, card: Card, playerName?: string) => {
-  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
+const submitCard: Move<GameState> = ({ G, ctx, playerID, player, gamelog, chat }: any, card: Card, playerName?: string) => {
+  if (player.isKicked(playerID)) return INVALID_MOVE;
   card.id = G.cards.length + 1; // Commit ID sequentially to GameState
   G.cards.push(card);
   if (ctx.numPlayers > 1) {
@@ -130,9 +128,9 @@ const submitCard: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, c
   }
 }
 
-const loadCards: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, cards: Card[]) => {
-  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
-  if(playerID !== (G.hostPlayerID ?? '0')) return INVALID_MOVE; // Only the host can bulk load cards
+const loadCards: Move<GameState> = ({ G, ctx, playerID, player, gamelog, chat }: any, cards: Card[]) => {
+  if (player.isKicked(playerID)) return INVALID_MOVE;
+  if(!player.isHost(playerID)) return INVALID_MOVE; // Only the host can bulk load cards
 
   // Bulk load batches of cards
   const loadBuffer: Card[] = [];
@@ -149,9 +147,9 @@ const loadCards: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, ca
   }
 }
 
-const shuffleCards: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any) => {
-  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
-  if(playerID !== (G.hostPlayerID ?? '0')) return INVALID_MOVE; // Only the host can reset the game
+const shuffleCards: Move<GameState> = ({ G, ctx, playerID, player, gamelog, chat }: any) => {
+  if (player.isKicked(playerID)) return INVALID_MOVE;
+  if(!player.isHost(playerID)) return INVALID_MOVE; // Only the host can reset the game
 
   // Return all cards to the deck, except those in the box
   G.cards.forEach((card: Card) => { 
@@ -168,8 +166,8 @@ const shuffleCards: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any)
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const postMessage: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, text: string, playerName?: string) => {
-  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
+const postMessage: Move<GameState> = ({ ctx, playerID, player, gamelog, chat }: any, text: string, playerName?: string) => {
+  if (player.isKicked(playerID)) return INVALID_MOVE;
   if (ctx.numPlayers <= 1) return INVALID_MOVE;
   if (!text || text.length > 500) return INVALID_MOVE;
   gamelog.record({ move: 'postMessage', playerID, playerName, text: text.trim() });
@@ -177,8 +175,8 @@ const postMessage: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, 
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const declareRule: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, text: string, playerName?: string) => {
-  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
+const declareRule: Move<GameState> = ({ G, ctx, playerID, player, gamelog, chat }: any, text: string, playerName?: string) => {
+  if (player.isKicked(playerID)) return INVALID_MOVE;
   if (ctx.numPlayers <= 1) return INVALID_MOVE;
   if (!text || text.trim().length === 0 || text.length > 200) return INVALID_MOVE;
 
@@ -198,8 +196,8 @@ const declareRule: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, 
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const revokeRule: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, ruleId: number, playerName?: string) => {
-  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
+const revokeRule: Move<GameState> = ({ G, ctx, playerID, player, gamelog, chat }: any, ruleId: number, playerName?: string) => {
+  if (player.isKicked(playerID)) return INVALID_MOVE;
   if (ctx.numPlayers <= 1) return INVALID_MOVE;
 
   const rules = G.rules ?? [];
@@ -207,7 +205,7 @@ const revokeRule: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, r
   if (ruleIndex === -1) return INVALID_MOVE;
 
   const rule = rules[ruleIndex];
-  if (playerID !== rule.playerID && playerID !== (G.hostPlayerID ?? '0')) return INVALID_MOVE;
+  if (playerID !== rule.playerID && !player.isHost(playerID)) return INVALID_MOVE;
 
   G.rules = rules.filter((r: Rule) => r.id !== ruleId);
 
@@ -216,10 +214,11 @@ const revokeRule: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, r
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const setScore: Move<GameState> = ({ G, ctx, playerID, player, gamelog, chat }: any, targetPlayerID: string, value: number, setterName?: string, targetName?: string) => {
-  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
+const setScore: Move<GameState> = ({ ctx, playerID, player, gamelog, chat }: any, targetPlayerID: string, value: number, setterName?: string, targetName?: string) => {
+  if (player.isKicked(playerID)) return INVALID_MOVE;
   if (player?.state && targetPlayerID in player.state) {
     const prev = player.state[targetPlayerID]?.score ?? 0;
+    if (value === prev) return;
     player.state[targetPlayerID] = { score: value };
     if (ctx.numPlayers > 1) {
       const delta = value - prev;
@@ -232,26 +231,23 @@ const setScore: Move<GameState> = ({ G, ctx, playerID, player, gamelog, chat }: 
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const transferHost: Move<GameState> = ({ G, playerID, gamelog, chat }: any, targetHostID: string) => {
-  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
-  if (targetHostID === (G.hostPlayerID ?? '0')) return INVALID_MOVE; // Already host
-  if (G.kickedPlayers?.includes(targetHostID)) return INVALID_MOVE; // Can't transfer to kicked
+const transferHost: Move<GameState> = ({ playerID, player, gamelog, chat }: any, targetHostID: string) => {
+  if (player.isKicked(playerID)) return INVALID_MOVE;
+  if (player.isHost(targetHostID)) return INVALID_MOVE; // Already host
+  if (player.isKicked(targetHostID)) return INVALID_MOVE; // Can't transfer to kicked
 
-  G.hostPlayerID = targetHostID;
+  player.setHost(targetHostID);
   gamelog.record({ move: 'transferHost', playerID, newHostID: targetHostID });
   chat.syncFromLog(gamelog.entries());
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const forceLeave: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, targetPlayerID: string, playerName?: string) => {
-  if (G.kickedPlayers?.includes(playerID)) return INVALID_MOVE;
-  if (playerID !== (G.hostPlayerID ?? '0')) return INVALID_MOVE; // Only host can kick
-  if (targetPlayerID === (G.hostPlayerID ?? '0')) return INVALID_MOVE; // Can't kick yourself
+const forceLeave: Move<GameState> = ({ G, ctx, playerID, player, gamelog, chat }: any, targetPlayerID: string, playerName?: string) => {
+  if (player.isKicked(playerID)) return INVALID_MOVE;
+  if (!player.isHost(playerID)) return INVALID_MOVE; // Only host can kick
+  if (player.isHost(targetPlayerID)) return INVALID_MOVE; // Can't kick yourself
   if (ctx.numPlayers <= 1) return INVALID_MOVE;
-
-  // Initialize kick list if needed
-  if (!G.kickedPlayers) G.kickedPlayers = [];
-  if (G.kickedPlayers.includes(targetPlayerID)) return INVALID_MOVE; // Already kicked
+  if (player.isKicked(targetPlayerID)) return INVALID_MOVE; // Already kicked
 
   // Return target's hand and table cards to deck
   G.cards.filter((c: Card) => c.owner === targetPlayerID).forEach((card: Card) => {
@@ -262,7 +258,7 @@ const forceLeave: Move<GameState> = ({ G, ctx, playerID, gamelog, chat }: any, t
   });
 
   // Mark as kicked
-  G.kickedPlayers.push(targetPlayerID);
+  player.kick(targetPlayerID);
 
   gamelog.record({ move: 'forceLeave', playerID, targetPlayerID, playerName });
   chat.syncFromLog(gamelog.entries());
@@ -275,17 +271,17 @@ export const BlankWhiteCards: Game<GameState> = {
   setup: (_, setupData) => {
     const preset = (setupData?.presetDeck || 'blank') as string;
     if (preset == 'blank') {
-      return { cards: [], rules: [], hostPlayerID: '0' }; // Blank White Deck
+      return { cards: [], rules: [] }; // Blank White Deck
     } else {
       try {
         const deck = presetDecks[preset] // Look for a matching preset deck
         if (deck) {
-          return { ...deck, rules: deck.rules ?? [], hostPlayerID: '0' };
+          return { ...deck, rules: deck.rules ?? [] };
         }
       } catch (e) {
         console.error(e);
       }
-      return { cards: [], rules: [], hostPlayerID: '0' }; // Blank White Deck as fallback
+      return { cards: [], rules: [] }; // Blank White Deck as fallback
     }
   },
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -21,4 +21,5 @@ wired-dialog renders at `z-index: 100` (via `--wired-dialog-z-index`). Anything 
 | 60 | Console toggle + panel | Console |
 | 60 | DeckEditor modals / image picker | DeckEditor |
 | 60 | CardEditor modal | CardEditor |
+| 100 | Calculator modal overlay | Calculator |
 | 110 | Focus overlay (fullscreen card focus, beats wired-dialog) | Focus |

--- a/engine/src/plugins/plugin-player.ts
+++ b/engine/src/plugins/plugin-player.ts
@@ -10,6 +10,8 @@ import type { Plugin, PlayerID } from '../types';
 
 interface PlayerData<PlayerState extends any = any> {
   players: Record<PlayerID, PlayerState>;
+  hostPlayerID: string;
+  kickedPlayers: string[];
 }
 
 export interface PlayerAPI<PlayerState extends any = any> {
@@ -20,6 +22,12 @@ export interface PlayerAPI<PlayerState extends any = any> {
     get(): PlayerState;
     set(value: PlayerState): PlayerState;
   };
+  hostPlayerID: string;
+  kickedPlayers: string[];
+  isHost(playerID: string): boolean;
+  isKicked(playerID: string): boolean;
+  setHost(playerID: string): void;
+  kick(playerID: string): void;
 }
 
 interface PluginPlayerOpts<PlayerState extends any = any> {
@@ -50,8 +58,12 @@ const PlayerPlugin = <PlayerState extends any = any>({
 > => ({
   name: 'player',
 
-  flush: ({ api }) => {
-    return { players: api.state };
+  flush: ({ api, data }) => {
+    return {
+      players: api.state,
+      hostPlayerID: data.hostPlayerID ?? '0',
+      kickedPlayers: data.kickedPlayers ?? [],
+    };
   },
 
   api: ({ ctx, data }): PlayerAPI => {
@@ -65,7 +77,25 @@ const PlayerPlugin = <PlayerState extends any = any>({
       return (state[ctx.currentPlayer] = value);
     };
 
-    const result: PlayerAPI = { state, get, set };
+    const isHost = (playerID: string) => playerID === data.hostPlayerID;
+    const isKicked = (playerID: string) => (data.kickedPlayers ?? []).includes(playerID);
+    const setHost = (playerID: string) => { data.hostPlayerID = playerID; };
+    const kick = (playerID: string) => {
+      if (!data.kickedPlayers) data.kickedPlayers = [];
+      data.kickedPlayers.push(playerID);
+    };
+
+    const result: PlayerAPI = {
+      state,
+      get,
+      set,
+      get hostPlayerID() { return data.hostPlayerID ?? '0'; },
+      get kickedPlayers() { return data.kickedPlayers ?? []; },
+      isHost,
+      isKicked,
+      setHost,
+      kick,
+    };
 
     if (ctx.numPlayers === 2) {
       const other = ctx.currentPlayer === '0' ? '1' : '0';
@@ -90,11 +120,19 @@ const PlayerPlugin = <PlayerState extends any = any>({
       }
       players[i + ''] = playerState;
     }
-    return { players };
+    return { players, hostPlayerID: '0', kickedPlayers: [] };
   },
 
-  playerView: ({ data, playerID }) =>
-    playerView ? { players: playerView(data.players, playerID) } : data,
+  playerView: ({ data, playerID }) => {
+    if (playerView) {
+      return {
+        players: playerView(data.players, playerID),
+        hostPlayerID: data.hostPlayerID ?? '0',
+        kickedPlayers: data.kickedPlayers ?? [],
+      };
+    }
+    return data;
+  },
 });
 
 export default PlayerPlugin;

--- a/engine/src/plugins/plugin-player.ts
+++ b/engine/src/plugins/plugin-player.ts
@@ -59,6 +59,9 @@ const PlayerPlugin = <PlayerState extends any = any>({
   name: 'player',
 
   flush: ({ api, data }) => {
+    // Player scores come from api.state (mutated via api.set/state assignment in moves),
+    // but hostPlayerID/kickedPlayers are mutated directly on `data` by setHost()/kick()
+    // since they're session-level concerns shared across all players, not per-player state.
     return {
       players: api.state,
       hostPlayerID: data.hostPlayerID ?? '0',

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -917,7 +917,7 @@ mcp.registerTool(
   async ({ matchID, playerID }) => {
     const { client } = requireSession(matchID, playerID);
     const currentState = client.getState();
-    const hostID = (currentState?.G as any)?.hostPlayerID ?? '0';
+    const hostID = (currentState?.plugins as any)?.player?.data?.hostPlayerID ?? '0';
     if (playerID !== hostID) throw new Error(`shuffle_cards is host-only. You are player ${playerID}. The current host is player ${hostID}.`);
     const nextState = waitForMove(client);
     client.moves.shuffleCards();
@@ -945,7 +945,7 @@ mcp.registerTool(
   async ({ matchID, playerID, cards }) => {
     const { client } = requireSession(matchID, playerID);
     const currentState = client.getState();
-    const hostID = (currentState?.G as any)?.hostPlayerID ?? '0';
+    const hostID = (currentState?.plugins as any)?.player?.data?.hostPlayerID ?? '0';
     if (playerID !== hostID) throw new Error(`load_cards is host-only. You are player ${playerID}. The current host is player ${hostID}.`);
     const cardObjects: Partial<Card>[] = await Promise.all(cards.map(async c => {
       let image: string | undefined;


### PR DESCRIPTION
## Summary

Moves `hostPlayerID` and `kickedPlayers` out of `GameState` (G) into the PluginPlayer data where they belong — host identity and kick status are session/player concerns, not game data.

## Changes

**Engine (`plugin-player.ts`):**
- Extended `PlayerData` with `hostPlayerID` and `kickedPlayers`
- Added API helpers: `isHost()`, `isKicked()`, `setHost()`, `kick()`
- Plugin `setup` initializes `hostPlayerID: '0'`, `kickedPlayers: []`
- `flush` and `playerView` expose both fields to clients

**Core (`Game.ts`):**
- Removed `hostPlayerID` and `kickedPlayers` from `GameState` interface
- All moves use `player.isHost()` / `player.isKicked()` instead of reading from G
- `transferHost` calls `player.setHost()`, `forceLeave` calls `player.kick()`

**Client:**
- All components read from `plugins.player.data.hostPlayerID` / `kickedPlayers`
- Host badge: MUI `StarOutlined` icon in header (replaces emoji)
- Kick button: plain × in top-right corner of avatar box, black
- Calculator: refactored to portal for z-index reliability

**MCP Server:**
- Host checks read from `plugins.player.data` path

## Testing

All 9 unit tests pass — host transfer, kick, move blocking, non-host rejection verified. `G.hostPlayerID` confirmed `undefined` after refactor.

Resolves BWC-63